### PR TITLE
add Makefile.win

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,9 @@
+BINDIR    := $(CURDIR)/bin
+GO        ?= go
+GOFLAGS   :=
+TAGS      :=
+LDFLAGS   := -w -s
+
+.PHONY: build
+build:
+	$(GO) build -o $(BINDIR)/duffle.exe $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' github.com/deis/duffle/cmd/...


### PR DESCRIPTION
Windows-compatible Makefile with GnuMake.

Usage: `make -f Makefile.win`