### PR TITLE
Implement duffle version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ GOFLAGS   :=
 TAGS      :=
 LDFLAGS   := -w -s
 
+GIT_TAG  := $(shell git describe --tags --always)
+VERSION  ?= ${GIT_TAG}
+LDFLAGS  += -X github.com/deis/duffle/pkg/version.Version=$(VERSION)
+
 .PHONY: build
 build:
 	GOBIN=$(BINDIR) $(GO) install $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' github.com/deis/duffle/cmd/...

--- a/cmd/duffle/root.go
+++ b/cmd/duffle/root.go
@@ -24,6 +24,7 @@ func newRootCmd(w io.Writer) *cobra.Command {
 	cmd.AddCommand(newPullCmd(w))
 	cmd.AddCommand(newPushCmd(w))
 	cmd.AddCommand(newRunCmd(w))
+	cmd.AddCommand(newVersionCmd(w))
 
 	return cmd
 }

--- a/cmd/duffle/version.go
+++ b/cmd/duffle/version.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/deis/duffle/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+func newVersionCmd(w io.Writer) *cobra.Command {
+	const usage = `Prints current version of the Duffle CLI`
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: usage,
+		Long:  usage,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version.Version)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the current version of Duffle
+var Version = ""


### PR DESCRIPTION
This PR adds a version command to Duffle.
Also tested on Windows.

closes #27 