### PR TITLE
Parameter definitions deserialiser

### DIFF
--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -31,7 +31,8 @@ type Image struct {
 
 // Metadata is a CNAB metadata document
 type Metadata struct {
-	Name    string  `json:"name"`
-	Version string  `json:"version"`
-	Images  []Image `json:"images"`
+	Name       string                         `json:"name"`
+	Version    string                         `json:"version"`
+	Images     []Image                        `json:"images"`
+	Parameters map[string]ParameterDefinition `json:"parameters"`
 }

--- a/pkg/metadata/parameterdefs.go
+++ b/pkg/metadata/parameterdefs.go
@@ -1,27 +1,8 @@
 package metadata
 
 import (
-	"encoding/json"
 	"fmt"
 )
-
-// ParseParameterDefinitionsBuffer reads CNAB parameter definitions from a JSON byte stream
-func ParseParameterDefinitionsBuffer(data []byte) (ParameterDefinitions, error) {
-	definitions := ParameterDefinitions{}
-	err := json.Unmarshal(data, &definitions)
-	return definitions, err
-}
-
-// ParseParameterDefinitions reads CNAB parameter definitions from a JSON string
-func ParseParameterDefinitions(text string) (ParameterDefinitions, error) {
-	return ParseParameterDefinitionsBuffer([]byte(text))
-}
-
-// ParameterDefinitions describes a set of parameters defined for
-// a CNAB bundle
-type ParameterDefinitions struct {
-	Parameters map[string]ParameterDefinition `json:"parameters"`
-}
 
 // ParameterDefinition defines a single parameter for a CNAB bundle
 type ParameterDefinition struct {

--- a/pkg/metadata/parameterdefs_test.go
+++ b/pkg/metadata/parameterdefs_test.go
@@ -12,7 +12,7 @@ func TestCanReadParameterNames(t *testing.T) {
 			"bar": { }
 		}
 	}`
-	definitions, err := ParseParameterDefinitions(json)
+	definitions, err := Parse(json)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestCanReadParameterDefinition(t *testing.T) {
 		dataType, defaultValue, allowedValues0, allowedValues1,
 		minValue, maxValue, minLength, maxLength, description)
 
-	definitions, err := ParseParameterDefinitions(json)
+	definitions, err := Parse(json)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,21 +140,21 @@ func TestCanReadValues(t *testing.T) {
 	intValue := "123"
 	boolValue := "true"
 
-	strDef, err := ParseParameterDefinitions(valueTestJSON(strValue))
+	strDef, err := Parse(valueTestJSON(strValue))
 	if err != nil {
 		t.Fatal(err)
 	}
 	expectString("default value", "some string", strDef.Parameters["test"].DefaultValue, t)
 	expectString("allowed value", "some string", strDef.Parameters["test"].AllowedValues[0], t)
 
-	intDef, err := ParseParameterDefinitions(valueTestJSON(intValue))
+	intDef, err := Parse(valueTestJSON(intValue))
 	if err != nil {
 		t.Fatal(err)
 	}
 	expectInt("default value", 123, intDef.Parameters["test"].DefaultValue, t)
 	expectInt("allowed value", 123, intDef.Parameters["test"].AllowedValues[0], t)
 
-	boolDef, err := ParseParameterDefinitions(valueTestJSON(boolValue))
+	boolDef, err := Parse(valueTestJSON(boolValue))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Reads the ARM parameter definition schema and validates parameter values against it.  (Currently does not validate the definitions themselves.)

Fixes #18 and #55.