### PR TITLE
implement `duffle init`

### DIFF
--- a/cmd/duffle/init.go
+++ b/cmd/duffle/init.go
@@ -1,23 +1,95 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"os"
+	"strings"
 
+	"github.com/deis/duffle/pkg/duffle/home"
+	"github.com/deis/duffle/pkg/ohai"
 	"github.com/spf13/cobra"
 )
 
-// TODO
+const (
+	initDesc = `
+Initializes duffle with configuration required to start installing CNAB bundles.
+`
+)
+
+type initCmd struct {
+	dryRun bool
+	w      io.Writer
+}
+
 func newInitCmd(w io.Writer) *cobra.Command {
-	const usage = `TODO`
+	i := &initCmd{w: w}
 
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: usage,
-		Long:  usage,
-		Run: func(cmd *cobra.Command, args []string) {
-			unimplemented("duffle init")
+		Short: "sets up local environment to work with duffle",
+		Long:  initDesc,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return i.run()
 		},
 	}
 
+	f := cmd.Flags()
+	f.BoolVar(&i.dryRun, "dry-run", false, "go through all the steps without actually installing anything")
+
 	return cmd
+}
+
+func (i *initCmd) run() error {
+	home := home.Home(homePath())
+	dirs := []string{
+		home.String(),
+		home.Logs(),
+		home.Plugins(),
+		home.Repositories(),
+	}
+
+	if err := i.ensureDirectories(dirs); err != nil {
+		return err
+	}
+	// TODO: add repos here
+	// return i.ensureRepositories()
+	return nil
+}
+
+// ensureRepositories checks to see if the default repositories exists.
+//
+// If the repo does not exist, this function will create it.
+func (i *initCmd) ensureRepositories() error {
+	ohai.Fohailn(i.w, "Installing default repositories...")
+
+	// TODO: add repos here
+	addArgs := []string{}
+
+	repoCmd, _, err := rootCmd.Find([]string{"repo", "add"})
+	if err != nil {
+		return err
+	}
+	if i.dryRun {
+		return nil
+	}
+	return repoCmd.RunE(repoCmd, addArgs)
+}
+
+func (i *initCmd) ensureDirectories(dirs []string) error {
+	fmt.Fprintln(i.w, "The following new directories will be created:")
+	fmt.Fprintln(i.w, strings.Join(dirs, "\n"))
+	for _, dir := range dirs {
+		if fi, err := os.Stat(dir); err != nil {
+			if !i.dryRun {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return fmt.Errorf("Could not create %s: %s", dir, err)
+				}
+			}
+		} else if !fi.IsDir() {
+			return fmt.Errorf("%s must be a directory", dir)
+		}
+	}
+	return nil
 }

--- a/cmd/duffle/main.go
+++ b/cmd/duffle/main.go
@@ -6,12 +6,15 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/spf13/cobra"
+
 	"github.com/deis/duffle/pkg/duffle/home"
 )
 
 var (
 	// duffleHome depicts the home directory where all duffle config is stored.
 	duffleHome string
+	rootCmd    *cobra.Command
 )
 
 func unimplemented(msg string) {
@@ -50,5 +53,6 @@ func main() {
 			}
 		}
 	}()
-	must(newRootCmd(os.Stdout).Execute())
+	rootCmd = newRootCmd(os.Stdout)
+	must(rootCmd.Execute())
 }


### PR DESCRIPTION
rebased on top of #73 since some of `duffle init` works with repositories.