### PR TITLE
fix linter error

### DIFF
--- a/pkg/builder/errors.go
+++ b/pkg/builder/errors.go
@@ -4,5 +4,5 @@ import "errors"
 
 var (
 	// ErrDockerfileNotExist is returned when no Dockerfile exists during "duffle build."
-	ErrDockerfileNotExist = errors.New("Dockerfile does not exist.")
+	ErrDockerfileNotExist = errors.New("Dockerfile does not exist")
 )


### PR DESCRIPTION
error messages should not end with punctuation