### PR TITLE
implement HAS_DEP on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ LDFLAGS   := -w -s
 
 ifeq ($(OS),Windows_NT)
 	TARGET = duffle.exe
+	SHELL = cmd.exe
+	HAS_DEP := $(shell where.exe dep)
 else
 	TARGET = duffle
 	HAS_DEP := $(shell command -v dep;)


### PR DESCRIPTION
we need to set SHELL to cmd.exe so we can find WHERE.exe. By default sh.exe is used which doesn't exist on Windows 10, but likely is some mingw assumption made by the Make developers(?).