### PR TITLE
Put Dockerfile in expected duffle directory in example for build

### DIFF
--- a/examples/helloworld/cnab/Dockerfile
+++ b/examples/helloworld/cnab/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
-COPY cnab/app/run /cnab/app/run
-COPY cnab/bundle.json /cnab/bundle.json
+COPY app/run /cnab/app/run
+COPY bundle.json /cnab/bundle.json
 COPY Dockerfile cnab/Dockerfile
 
 CMD [ "/cnab/app/run" ]


### PR DESCRIPTION
As per the expected convention for the builder, it expects a Dockerfile in the directory of the "component", as defined in `duffle.toml`.

This PR moves the Dockerfile for the example in the `helloworld/cnab` directory and updates the Dockerfile with the new paths.

To test:

```
$ cd examples/helloworld/
$ duffle build
Duffle Build Started: 'helloworld': 01CNHM83V5QW1K5HQ947RN0DDC
helloworld: Building Docker Images: SUCCESS ⚓  (1.0016s)

$ cat ~/.duffle/logs/helloworld/01CNHM83V5QW1K5HQ947RN0DDC
Step 1/5 : FROM alpine:latest
 ---> 11cd0b38bc3c
Step 2/5 : COPY app/run /cnab/app/run
 ---> Using cache
 ---> 7f1086d5b7ad
Step 3/5 : COPY bundle.json /cnab/bundle.json
 ---> Using cache
 ---> c555f0f50be3
Step 4/5 : COPY Dockerfile cnab/Dockerfile
 ---> Using cache
 ---> 4363db477a6a
Step 5/5 : CMD [ "/cnab/app/run" ]
 ---> Using cache
 ---> 6ee59529d96c
Successfully built 6ee59529d96c
Successfully tagged bacongobbler/helloworld-cnab:8051cd0ff613c8c9c75c14245d7a60bf2ed9ef58
```