### PR TITLE
Added duffle list command

### DIFF
--- a/cmd/duffle/list.go
+++ b/cmd/duffle/list.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/deis/duffle/pkg/claim"
+	"github.com/deis/duffle/pkg/duffle/home"
+	"github.com/deis/duffle/pkg/utils/crud"
+	"github.com/spf13/cobra"
+)
+
+func newListCmd(w io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list installed apps",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO: unify with similar code in duffle install currently awaiting PR
+			claimsPath := home.Home(homePath()).Claims()
+			claimsStore := claim.NewClaimStore(crud.NewFileSystemStore(claimsPath, "json"))
+			claims, err := claimsStore.List()
+			if err != nil {
+				return err
+			}
+
+			for _, claim := range claims {
+				fmt.Fprintln(w, claim)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/duffle/root.go
+++ b/cmd/duffle/root.go
@@ -21,6 +21,7 @@ func newRootCmd(w io.Writer) *cobra.Command {
 
 	cmd.AddCommand(newBuildCmd(w))
 	cmd.AddCommand(newInitCmd(w))
+	cmd.AddCommand(newListCmd(w))
 	cmd.AddCommand(newPullCmd(w))
 	cmd.AddCommand(newPushCmd(w))
 	cmd.AddCommand(newRepoCmd(w))


### PR DESCRIPTION
Currently displays only claim names, with no header.  @bacongobbler suggested also displaying the revision but I'm not sure how meaningful that is...?

Fixes #57.