### PR TITLE
fix: pass image type from bundle.json to claim and to driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/
 vendor/
 .vimrc
 *.exe
+.DS_Store
+.vscode/

--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -79,7 +79,7 @@ Windows Example:
 				return err
 			}
 
-			if err = validateDockerish(bundle.InvocationImage.Image); err != nil {
+			if err = validateImage(bundle.InvocationImage); err != nil {
 				return err
 			}
 
@@ -92,6 +92,7 @@ Windows Example:
 			// load the claim based on installationName
 			c := claim.New(installationName)
 			c.Bundle = bundle.InvocationImage.Image
+			c.ImageType = bundle.InvocationImage.ImageType
 			if valuesFile != "" {
 				vals, err := parseValues(valuesFile)
 				if err != nil {
@@ -130,6 +131,15 @@ func prepareDriver(driverName string) (driver.Driver, error) {
 	}
 
 	return driverImpl, err
+}
+
+func validateImage(img bundle.InvocationImage) error {
+	switch img.ImageType {
+	case "docker", "oci":
+		return validateDockerish(img.Image)
+	default:
+		return nil
+	}
 }
 
 func validateDockerish(s string) error {

--- a/examples/helloazure/cnab/app/run
+++ b/examples/helloazure/cnab/app/run
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+#set -eo pipefail
+
+action=$CNAB_ACTION
+name=$CNAB_INSTALLATION_NAME 
+
+case $action in
+    install)
+    echo "Install action"
+    ;;
+    uninstall)
+    echo "uninstall action"
+    ;;
+    upgrade)
+    echo "Upgrade action"
+    ;;
+    downgrade)
+    echo "Downgrade action"
+    ;;
+    status)
+    echo "Status action"
+    ;;
+    *)
+    echo "No action for $action"
+    ;;
+esac
+echo "Action $action complete for $name"

--- a/examples/helloazure/cnab/bundle.json
+++ b/examples/helloazure/cnab/bundle.json
@@ -1,0 +1,9 @@
+{
+    "name": "helloworld",
+    "version": "0.1.0",
+    "parameters": {},
+    "invocationImage": {
+        "imageType": "azure-image",
+        "image": "duffle-dev/duffle-vm-example-0.1.1"
+    }
+}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -25,7 +25,7 @@ func opFromClaim(action string, c *claim.Claim) *driver.Operation {
 		Parameters:   c.Parameters,
 		Credentials:  []driver.ResolvedCred{},
 		Image:        c.Bundle,
-		ImageType:    driver.ImageTypeDocker,
+		ImageType:    c.ImageType,
 		Revision:     c.Revision,
 	}
 }

--- a/pkg/claim/claim.go
+++ b/pkg/claim/claim.go
@@ -38,6 +38,7 @@ type Claim struct {
 	Bundle     string                 `json:"bundle"`
 	Result     Result                 `json:"result"`
 	Parameters map[string]interface{} `json:"parameters"`
+	ImageType  string                 `json:"image_type"`
 }
 
 // New creates a new Claim initialized for an installation operation.


### PR DESCRIPTION
This also adds an example of a VM-based bundle