### PR TITLE
initialize with deis/bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,3 @@ $ duffle install foo -f examples/helloworld/cnab/bundle.json
 
 
 For more information, see the [docs](docs/).
-
-## Add a Repo
-
-To test against a CNAB repository:
-
-```console
-$ duffle repo add ssh://git@github.com/deis/bundles.git
-```

--- a/cmd/duffle/init.go
+++ b/cmd/duffle/init.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/deis/duffle/pkg/duffle/home"
+	"github.com/deis/duffle/pkg/ohai"
 
 	"github.com/spf13/cobra"
 )
@@ -52,28 +53,20 @@ func (i *initCmd) run() error {
 		home.Credentials(),
 	}
 
-	// The only way I can get linter to pass is by commenting this out and simplifying
-	// See issue #113
-	return i.ensureDirectories(dirs)
-	/*
-		if err := i.ensureDirectories(dirs); err != nil {
-			return err
-		}
-		// TODO: add repos here
-		// return i.ensureRepositories()
-		return nil
-	*/
+	if err := i.ensureDirectories(dirs); err != nil {
+		return err
+	}
+	return i.ensureRepositories()
 }
 
 // ensureRepositories checks to see if the default repositories exists.
 //
 // If the repo does not exist, this function will create it.
-/* See #115 - commented out to appease angry linter
 func (i *initCmd) ensureRepositories() error {
 	ohai.Fohailn(i.w, "Installing default repositories...")
 
 	// TODO: add repos here
-	addArgs := []string{}
+	addArgs := []string{"ssh://git@github.com/deis/bundles.git"}
 
 	repoCmd, _, err := rootCmd.Find([]string{"repo", "add"})
 	if err != nil {
@@ -84,7 +77,6 @@ func (i *initCmd) ensureRepositories() error {
 	}
 	return repoCmd.RunE(repoCmd, addArgs)
 }
-*/
 
 func (i *initCmd) ensureDirectories(dirs []string) error {
 	fmt.Fprintln(i.w, "The following new directories will be created:")


### PR DESCRIPTION
I'm getting the foggiest error when trying to fetch this via `duffle init` or `duffle repo add`, but this *should* work.

```
><> .\bin\duffle.exe repo add ssh://git@github.com/deis/bundles.git
Error: repository does not exist
Usage:
  duffle repo add <repo> [name] [flags]

Flags:
  -h, --help   help for add

Global Flags:
      --home string   location of your Duffle config. Overrides $DUFFLE_HOME (default "C:\\Users\\mafishe\\.duffle")

duffle: fatal: repository does not exist
```

closes #113