### PR TITLE
remove osutil.SymlinkWithFallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ## Getting Started
 
-1. Clone this repo: `$ git clone git@github.com:deis/duffle.git`
-2. Vendor dependencies and build the `duffle` binary: `$ make bootstrap build`
-3. Call `duffle init`
+1. Ensure you're running the latest version of Go (1.11+)
+2. Clone this repo: `$ git clone git@github.com:deis/duffle.git`
+3. Vendor dependencies and build the `duffle` binary: `$ make bootstrap build`
+4. Call `duffle init`
 
 Once you have everything configured, you can start installing bundles!
 

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -3,8 +3,6 @@ package osutil
 import (
 	"fmt"
 	"os"
-	"runtime"
-	"syscall"
 )
 
 // Exists returns whether the given file or directory exists or not.
@@ -17,24 +15,6 @@ func Exists(path string) (bool, error) {
 		return false, nil
 	}
 	return true, err
-}
-
-// SymlinkWithFallback attempts to symlink a file or directory, but falls back to a move operation
-// in the event of the user not having the required privileges to create the symlink.
-func SymlinkWithFallback(oldname, newname string) (err error) {
-	err = os.Symlink(oldname, newname)
-	if runtime.GOOS == "windows" {
-		// If creating the symlink fails on Windows because the user
-		// does not have the required privileges, ignore the error and
-		// fall back to renaming the file.
-		//
-		// ERROR_PRIVILEGE_NOT_HELD is 0x522:
-		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms681385(v=vs.85).aspx
-		if lerr, ok := err.(*os.LinkError); ok && lerr.Err == syscall.Errno(0x522) {
-			err = os.Rename(oldname, newname)
-		}
-	}
-	return
 }
 
 // EnsureDirectory checks if a directory exists and creates it if it doesn't exist

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -3,7 +3,6 @@ package osutil
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -30,30 +29,5 @@ func TestExists(t *testing.T) {
 	}
 	if stillExists {
 		t.Error("expected tempfile to NOT exist after removing it")
-	}
-}
-
-func TestSymlinkWithFallback(t *testing.T) {
-	const (
-		oldFileName = "foo.txt"
-		newFileName = "bar.txt"
-	)
-	tmpDir, err := ioutil.TempDir("", "osutil")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	oldFileNamePath := filepath.Join(tmpDir, oldFileName)
-	newFileNamePath := filepath.Join(tmpDir, newFileName)
-
-	oldFile, err := os.Create(filepath.Join(tmpDir, oldFileName))
-	if err != nil {
-		t.Fatal(err)
-	}
-	oldFile.Close()
-
-	if err := SymlinkWithFallback(oldFileNamePath, newFileNamePath); err != nil {
-		t.Errorf("expected no error when calling SymlinkWithFallback() on a file that exists, got %v", err)
 	}
 }

--- a/pkg/repo/installer/local_installer.go
+++ b/pkg/repo/installer/local_installer.go
@@ -1,10 +1,10 @@
 package installer
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/deis/duffle/pkg/duffle/home"
-	"github.com/deis/duffle/pkg/osutil"
 )
 
 // LocalInstaller installs rigs from the filesystem
@@ -66,5 +66,5 @@ func (i *LocalInstaller) link(from string) error {
 	if err != nil {
 		return err
 	}
-	return osutil.SymlinkWithFallback(origin, dest)
+	return os.Symlink(origin, dest)
 }


### PR DESCRIPTION
no longer necessary now with Go 1.11

closes #96