### PR TITLE
Do not leave trailing bits of bundle.json when overwriting in build

### DIFF
--- a/cmd/duffle/build.go
+++ b/cmd/duffle/build.go
@@ -167,7 +167,7 @@ func (b *buildCmd) run() (err error) {
 		bf.Images = append(bf.Images, bundle.Image{Name: c.Name, URI: c.Images[0]})
 	}
 
-	f, err := os.OpenFile("cnab/bundle.json", os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile("cnab/bundle.json", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `duffle build` command currently overwrites any `bundle.json` file in the `cnab` directory.  If the new file is shorter than the old one, then the trailing bits of the old one remain in the file, corrupting it.  This PR truncates the file before writing to it, so that the resulting file contains _only_ the new `bundle.json` content.