### PR TITLE
allow installing default bundles using their fully-qualified names

### DIFF
--- a/cmd/duffle/search.go
+++ b/cmd/duffle/search.go
@@ -90,10 +90,7 @@ func findNames() []string {
 			repoName = strings.TrimSuffix(repoName, string(os.PathSeparator)+filepath.Join("bundles", f.Name()))
 			// for Windows clients, we need to replace the path separator with forward slashes
 			repoName = strings.Replace(repoName, "\\", "/", -1)
-			name := bundleName
-			if repoName != home.DefaultRepository() {
-				name = path.Join(repoName, bundleName)
-			}
+			name := path.Join(repoName, bundleName)
 			bundleNames = append(bundleNames, name)
 		}
 		return nil

--- a/cmd/duffle/search_test.go
+++ b/cmd/duffle/search_test.go
@@ -16,8 +16,8 @@ func TestSearch(t *testing.T) {
 	duffleHome = filepath.Join(cwd, "..", "..", "tests", "testdata", "home")
 
 	expectedBundleList := []string{
-		"foo",
 		"github.com/customorg/duffle-bundles/foo",
+		"github.com/deis/bundles.git/foo",
 	}
 
 	bundleList := search([]string{})


### PR DESCRIPTION
This change makes findNames() return the fully-qualifiable name for each bundle rather than the short form. `duffle install helloworld helloworld` still works as duffle will expand it to its fully qualifiable name before searching.

closes #191

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>