### PR TITLE
WIP: implement `duffle pull`

### DIFF
--- a/cmd/duffle/credential_generate.go
+++ b/cmd/duffle/credential_generate.go
@@ -38,7 +38,7 @@ func newCredentialGenerateCmd(out io.Writer) *cobra.Command {
 		Short:   "generate a credentialset from a bundle",
 		Long:    credentialGenerateHelp,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			bf, err := bundleFileOrArg2(args, bundleFile, out)
+			bf, err := bundleFileOrArg2(args, bundleFile)
 			if err != nil {
 				return err
 			}

--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -15,6 +15,7 @@ import (
 	"github.com/deis/duffle/pkg/claim"
 	"github.com/deis/duffle/pkg/duffle/home"
 	"github.com/deis/duffle/pkg/loader"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
@@ -67,7 +68,7 @@ For unpublished CNAB bundles, you can also load the bundle.json directly:
 		Short: "install a CNAB bundle",
 		Long:  usage,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			bundleFile, err := bundleFileOrArg2(args, bundleFile, w)
+			bundleFile, err := bundleFileOrArg2(args, bundleFile)
 			if err != nil {
 				return err
 			}
@@ -131,7 +132,7 @@ For unpublished CNAB bundles, you can also load the bundle.json directly:
 	return cmd
 }
 
-func bundleFileOrArg2(args []string, bundleFile string, w io.Writer) (string, error) {
+func bundleFileOrArg2(args []string, bundleFile string) (string, error) {
 	switch {
 	case len(args) < 1:
 		return "", errors.New("This command requires at least one argument: NAME (name for the installation). It also requires a BUNDLE (CNAB bundle name) or file (using -f)\nValid inputs:\n\t$ duffle install NAME BUNDLE\n\t$ duffle install NAME -f path-to-bundle.json")
@@ -141,7 +142,7 @@ func bundleFileOrArg2(args []string, bundleFile string, w io.Writer) (string, er
 		return "", errors.New("required arguments are NAME (name of the installation) and BUNDLE (CNAB bundle name) or file")
 	case len(args) == 2:
 		var err error
-		bundleFile, err = findBundleJSON(args[1], w)
+		bundleFile, err = findBundleJSON(args[1])
 		if err != nil {
 			return "", err
 		}
@@ -209,8 +210,8 @@ func getBundleFile(bundleName string) (string, string, error) {
 	return filepath.Join(home.Repositories(), repo, "bundles", fmt.Sprintf("%s.json", name)), repo, nil
 }
 
-// findBundleJSON tries to find the JS file by search the repo index
-func findBundleJSON(bundleName string, w io.Writer) (string, error) {
+// findBundleJSON tries to find the JS file by searching the repo index
+func findBundleJSON(bundleName string) (string, error) {
 	relevantBundles := search([]string{bundleName})
 	switch len(relevantBundles) {
 	case 0:
@@ -234,7 +235,7 @@ func findBundleJSON(bundleName string, w io.Writer) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Fprintf(w, "loaded %s from repository %s\n", filePath, repo)
+	log.Debugf("loaded %s from repository %s\n", filePath, repo)
 	return filePath, nil
 }
 

--- a/cmd/duffle/pull.go
+++ b/cmd/duffle/pull.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -14,8 +16,16 @@ func newPullCmd(w io.Writer) *cobra.Command {
 		Use:   "pull",
 		Short: usage,
 		Long:  usage,
-		Run: func(cmd *cobra.Command, args []string) {
-			unimplemented("duffle pull")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("This command requires at least one argument: BUNDLE (CNAB bundle name)\nValid inputs:\n\t$ duffle pull BUNDLE")
+			}
+			bundleFile, err := findBundleJSON(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(w, bundleFile)
+			return nil
 		},
 	}
 

--- a/cmd/duffle/uninstall.go
+++ b/cmd/duffle/uninstall.go
@@ -33,7 +33,7 @@ func newUninstallCmd(w io.Writer) *cobra.Command {
 		Long:  usage,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uc.name = args[0]
-			bundleFile, err := bundleFileOrArg2(args, bundleFile, w)
+			bundleFile, err := bundleFileOrArg2(args, bundleFile)
 			// If no bundle was found, we just wait for the claim system
 			// to load its bundleFile
 			if err == nil {


### PR DESCRIPTION
Usage:

```
><> duffle pull helloworld
/home/bacongobbler/.duffle/repositories/github.com/deis/bundles.git/bundles/helloworld.json
```

This can then be scripted into `duffle install`:

```
><> duffle install helloworld -f $(duffle pull helloworld)
Executing install action...

Install action
Action install complete for helloworld
```

TODO:

- [ ] is this the acceptance criteria for `duffle pull`? What is the intended use case for `duffle pull` compared to running `duffle install helloworld helloworld`?
- [ ] do we want to do a more "deep" `duffle pull`, where we pull the underlying images from the bundle? cc  @radu-matei as he mentioned this in standup this morning
- [ ] right now, `duffle install` always fetches helloworld.json on each invocation. Do we want to use the cached bundle of helloworld.json if it's been fetched previously with `duffle pull`?