### PR TITLE
feat: add --set to install

### DIFF
--- a/cmd/duffle/install_test.go
+++ b/cmd/duffle/install_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/deis/duffle/pkg/bundle"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/deis/duffle/pkg/duffle/home"
 )
 
@@ -32,4 +35,27 @@ func TestGetBundleFile(t *testing.T) {
 	if repo != expectedRepo {
 		t.Errorf("got '%v', wanted '%v'", repo, expectedRepo)
 	}
+}
+
+func TestOverrides(t *testing.T) {
+	is := assert.New(t)
+	// overrides(overrides []string, paramDefs map[string]bundle.ParameterDefinition)
+	defs := map[string]bundle.ParameterDefinition{
+		"first":  {DataType: "string"},
+		"second": {DataType: "bool"},
+		"third":  {DataType: "int"},
+	}
+
+	setVals := []string{"first=foo", "second=true", "third=2", "fourth"}
+	o, err := overrides(setVals, defs)
+	is.NoError(err)
+
+	is.Len(o, 3)
+	is.Equal(o["first"].(string), "foo")
+	is.True(o["second"].(bool))
+	is.Equal(o["third"].(int), 2)
+
+	// We expect an error if we pass a param that was not defined:
+	_, err = overrides([]string{"undefined=foo"}, defs)
+	is.Error(err)
 }

--- a/cmd/duffle/upgrade.go
+++ b/cmd/duffle/upgrade.go
@@ -45,6 +45,7 @@ func newUpgradeCmd(w io.Writer) *cobra.Command {
 		},
 	}
 
+	// TODO: Don't we need to allow new parameters?
 	cmd.Flags().StringVarP(&upgradeDriver, "driver", "d", "docker", "Specify a driver name")
 	cmd.Flags().StringVarP(&credentialsFile, "credentials", "c", "", "Specify a set of credentials to use inside the CNAB bundle")
 

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -51,3 +51,19 @@ type Bundle struct {
 	Parameters      map[string]ParameterDefinition `json:"parameters" toml:"parameters"`
 	Credentials     map[string]CredentialLocation  `json:"credentials" toml:"credentials"`
 }
+
+// ValuesOrDefaults returns parameter values or the default parameter values
+func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
+	res := map[string]interface{}{}
+	for name, def := range b.Parameters {
+		if val, ok := vals[name]; ok {
+			if err := def.ValidateParameterValue(val); err != nil {
+				return res, err
+			}
+			res[name] = val
+			continue
+		}
+		res[name] = def.DefaultValue
+	}
+	return res, nil
+}

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -3,6 +3,8 @@ package bundle
 import (
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReadTopLevelProperties(t *testing.T) {
@@ -89,4 +91,46 @@ func TestReadCredentialProperties(t *testing.T) {
 	if q.EnvironmentVariable != "equux" {
 		t.Errorf("Expected env 'equux', got '%s'", q.EnvironmentVariable)
 	}
+}
+
+func TestValuesOrDefaults(t *testing.T) {
+	is := assert.New(t)
+	vals := map[string]interface{}{
+		"port":    8080,
+		"host":    "localhost",
+		"enabled": true,
+	}
+	b := &Bundle{
+		Parameters: map[string]ParameterDefinition{
+			"port": {
+				DataType:     "int",
+				DefaultValue: 1234,
+			},
+			"host": {
+				DataType:     "string",
+				DefaultValue: "localhost.localdomain",
+			},
+			"enabled": {
+				DataType:     "bool",
+				DefaultValue: false,
+			},
+			"replicaCount": {
+				DataType:     "int",
+				DefaultValue: 3,
+			},
+		},
+	}
+
+	vod, err := ValuesOrDefaults(vals, b)
+
+	is.NoError(err)
+	is.True(vod["enabled"].(bool))
+	is.Equal(vod["host"].(string), "localhost")
+	is.Equal(vod["port"].(int), 8080)
+	is.Equal(vod["replicaCount"].(int), 3)
+
+	// This should err out because of type problem
+	vals["replicaCount"] = "banana"
+	_, err = ValuesOrDefaults(vals, b)
+	is.Error(err)
 }

--- a/pkg/bundle/parameters.go
+++ b/pkg/bundle/parameters.go
@@ -1,7 +1,10 @@
 package bundle
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 // ParameterDefinition defines a single parameter for a CNAB bundle
@@ -38,7 +41,26 @@ func (pd ParameterDefinition) ValidateParameterValue(value interface{}) error {
 	case "bool":
 		return pd.validateBoolParameterValue(value)
 	default:
-		return fmt.Errorf("Invalid parameter definition")
+		return fmt.Errorf("invalid parameter definition")
+	}
+}
+
+// ConvertValue tries to convert the given value to the definition's DataType
+//
+// It will return an error if it cannot be converted
+func (pd ParameterDefinition) ConvertValue(val string) (interface{}, error) {
+	switch pd.DataType {
+	case "string":
+		return val, nil
+	case "int":
+		return strconv.Atoi(val)
+	case "bool":
+		if strings.ToLower(val) == "true" {
+			return true, nil
+		}
+		return false, nil
+	default:
+		return nil, errors.New("invalid parameter definition")
 	}
 }
 

--- a/pkg/bundle/parameters_test.go
+++ b/pkg/bundle/parameters_test.go
@@ -3,6 +3,8 @@ package bundle
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCanReadParameterNames(t *testing.T) {
@@ -325,6 +327,33 @@ func TestValidateBoolParameterValue(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected invalid type but got no error")
 	}
+}
+
+func TestConvertValue(t *testing.T) {
+	pd := ParameterDefinition{
+		DataType: "bool",
+	}
+	is := assert.New(t)
+
+	out, _ := pd.ConvertValue("true")
+	is.True(out.(bool))
+	out, _ = pd.ConvertValue("false")
+	is.False(out.(bool))
+	out, _ = pd.ConvertValue("barbeque")
+	is.False(out.(bool))
+
+	pd.DataType = "string"
+	out, err := pd.ConvertValue("hello")
+	is.NoError(err)
+	is.Equal("hello", out.(string))
+
+	pd.DataType = "int"
+	out, err = pd.ConvertValue("123")
+	is.NoError(err)
+	is.Equal(123, out.(int))
+
+	out, err = pd.ConvertValue("onetwothree")
+	is.Error(err)
 }
 
 func intPtr(i int) *int {


### PR DESCRIPTION
This adds `--set NAME=VAL` to `duffle install`. It also implements strict parameter checking, which I guess I neglected to do last time. 🐼 