### PR TITLE
update helloworld example to new schema

### DIFF
--- a/examples/helloworld/cnab/bundle.json
+++ b/examples/helloworld/cnab/bundle.json
@@ -1,12 +1,32 @@
 {
-    "name": "foo",
-    "version": "1.0",
+    "name": "helloworld",
+    "version": "aa2370d945960f8cdbc086c89702ae5215106c5c",
     "invocationImage": {
         "imageType": "docker",
-        "image": "technosophos/helloworld:0.1.0",
-        "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
-      },
+        "image": "microsoft/helloworld-cnab:aa2370d945960f8cdbc086c89702ae5215106c5c"
+    },
     "images": [],
-    "parameters": {},
-    "credentials": {}
+    "parameters": {
+        "hello": {
+            "type": "int",
+            "defaultValue": "1",
+            "allowedValues": [
+                "1",
+                "2"
+            ],
+            "minValue": 100,
+            "maxValue": 200,
+            "minLength": 100,
+            "maxLength": 200,
+            "metadata": {
+                "description": "hello"
+            }
+        }
+    },
+    "credentials": {
+        "quux": {
+            "path": "pquux",
+            "env": "equux"
+        }
+    }
 }

--- a/examples/helloworld/duffle.toml
+++ b/examples/helloworld/duffle.toml
@@ -1,11 +1,16 @@
 name = "helloworld"
-components = ["cnab"]
+
+[components]
+    [components.cnab]
+        name = "cnab"
+        builder = "docker"
+        configuration = { registry = "microsoft" }
 
 [parameters]
     [parameters.hello]
     type = "int"
-    defaultValue = "some default"
-    allowedValues = ["foo", "bar"]
+    defaultValue = "1"
+    allowedValues = ["1", "2"]
     minValue = 100
     maxValue = 200
     minLength = 100

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -85,6 +85,7 @@ func (b *Builder) PrepareBuild(bldr *Builder, mfst *manifest.Manifest, appDir st
 	wg.Add(len(ctx.Components))
 	bf := &bundle.Bundle{
 		Name:        ctx.Manifest.Name,
+		Images:      []bundle.Image{},
 		Parameters:  ctx.Manifest.Parameters,
 		Credentials: ctx.Manifest.Credentials,
 	}


### PR DESCRIPTION
Also fixes an issue where the `images` field in bundle.json was `null` rather than an empty array when no other components were specified.