### PR TITLE
feat(Makefile): add default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ GIT_TAG  := $(shell git describe --tags --always)
 VERSION  := ${GIT_TAG}
 LDFLAGS  += -X github.com/deis/duffle/pkg/version.Version=$(VERSION)
 
+.PHONY: default
+default: build
+
 .PHONY: build
 build:
 	go build $(GOFLAGS) -o $(BINDIR)/$(TARGET) -ldflags '$(LDFLAGS)' github.com/deis/duffle/cmd/...
@@ -24,7 +27,6 @@ build:
 .PHONY: debug
 debug:
 	go build $(GOFLAGS) -o $(BINDIR)/$(TARGET) github.com/deis/duffle/cmd/...
-
 
 .PHONY: test
 test:
@@ -36,7 +38,6 @@ lint:
 
 HAS_DEP          := $(shell $(CHECK) dep)
 HAS_GOMETALINTER := $(shell $(CHECK) gometalinter)
-
 
 .PHONY: build-drivers
 build-drivers:


### PR DESCRIPTION
Such that `make` from project root runs the default targets of `bootstrap` and `build`