### PR TITLE
[WIP] Add initial proposal for local repo management

### DIFF
--- a/docs/205-repo-management.md
+++ b/docs/205-repo-management.md
@@ -1,0 +1,14 @@
+# Local Repository Management
+
+This section describes how the Duffle tool interacts with local repositories of CNAB bundles.
+
+All local CNAB bundles are stored in repositories that can be found in `$DUFFLE_HOME/repositories`, following the `registry/<org>/<repository>/tags/<tag>/bundle.json` structure.
+
+> For exported bundles, a thick bundle (containing all assets in a single file) will be stored side-by-side with the bundle file under the corresponding tag.
+
+> The default registry is `https://hub.cnlabs.io/`, so any push / pull operation that doesn't include a registry will be executed against this registry.
+
+
+## Using the Duffle CLI with local bundles
+
+The Duffle CLI tool is primarily used with bundles found in `$DUFFLE_HOME/repositories`, and commands such as `install`, `push`, `pull` or `tag` will work with repositories there. However, commands that work with bundles also feature a `-f` flag that that helps the use of a bundle in a different place than `$DUFFLE_HOME`, but should be used in exceptional cases.


### PR DESCRIPTION
This WIP PR aims to define how the Duffle CLI tool works with local bundle repos, and before merging it, the workflow described here should be possible in `master`:

- [x] #234 - `duffle build` should publish `bundle.json` into `$DUFFLE_HOME/repositories`

- [x] #239 - `duffle install` should use bundle in local repository

- [x] #241 - `duffle push` and `duffle pull` should operate with bundles in `$DUFFLE_HOME/repositories`