### PR TITLE
switch duffle.toml to duffle.json

### DIFF
--- a/cmd/duffle/build.go
+++ b/cmd/duffle/build.go
@@ -12,6 +12,7 @@ import (
 	"github.com/deis/duffle/pkg/builder/docker"
 	"github.com/deis/duffle/pkg/builder/mock"
 	"github.com/deis/duffle/pkg/cmdline"
+	"github.com/deis/duffle/pkg/duffle"
 	"github.com/deis/duffle/pkg/duffle/home"
 	"github.com/deis/duffle/pkg/duffle/manifest"
 
@@ -110,7 +111,7 @@ func (b *buildCmd) run() (err error) {
 	)
 	bldr.LogsDir = b.home.Logs()
 
-	mfst, err := manifest.Load(filepath.Join(b.src, "duffle.toml"))
+	mfst, err := manifest.Load(filepath.Join(b.src, duffle.DuffleFilepath))
 	if err != nil {
 		return err
 	}

--- a/cmd/duffle/build_test.go
+++ b/cmd/duffle/build_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/deis/duffle/pkg/duffle"
 	"github.com/deis/duffle/pkg/duffle/home"
 )
 
@@ -27,12 +28,12 @@ func TestBuild(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(testBundlePath, "cnab"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	from, err := os.Open(filepath.Join("testdata", "testbundle", "duffle.toml"))
+	from, err := os.Open(filepath.Join("testdata", "testbundle", duffle.DuffleFilepath))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer from.Close()
-	dest := filepath.Join(testBundlePath, "duffle.toml")
+	dest := filepath.Join(testBundlePath, duffle.DuffleFilepath)
 	to, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/duffle/testdata/testbundle/duffle.json
+++ b/cmd/duffle/testdata/testbundle/duffle.json
@@ -1,0 +1,3 @@
+{
+    "name": "testbundle"
+}

--- a/cmd/duffle/testdata/testbundle/duffle.toml
+++ b/cmd/duffle/testdata/testbundle/duffle.toml
@@ -1,3 +1,0 @@
-name = "testbundle"
-registry = "testregistry"
-components = ["cnab"]

--- a/docs/203-duffle-build.md
+++ b/docs/203-duffle-build.md
@@ -1,3 +1,3 @@
 # Duffle Build
 
-This document describes how `duffle build` works, and how it uses `duffle.toml`.
+This document describes how `duffle build` works, and how it uses `duffle.json`.

--- a/pkg/duffle/create.go
+++ b/pkg/duffle/create.go
@@ -1,8 +1,8 @@
 package duffle
 
 const (
-	// DuffleTomlFilename is the default filename for Duffle application configuration.
-	DuffleTomlFilename = "duffle.toml"
-	// DuffleTomlFilepath is the relative path from the root of an application directory to duffle.toml
-	DuffleTomlFilepath = "duffle.toml"
+	// DuffleFilename is the default filename for Duffle application configuration.
+	DuffleFilename = "duffle.json"
+	// DuffleFilepath is the relative path from the root of an application directory to duffle.json
+	DuffleFilepath = DuffleFilename
 )

--- a/pkg/duffle/home/home.go
+++ b/pkg/duffle/home/home.go
@@ -25,11 +25,6 @@ func (h Home) Path(elem ...string) string {
 	return filepath.Join(p...)
 }
 
-// Config returns the path to the Duffle config file.
-func (h Home) Config() string {
-	return h.Path("config.toml")
-}
-
 // Repositories returns the path to the Duffle repositories.
 func (h Home) Repositories() string {
 	return h.Path("repositories")

--- a/pkg/duffle/manifest/load.go
+++ b/pkg/duffle/manifest/load.go
@@ -1,13 +1,19 @@
 package manifest
 
 import (
-	"github.com/BurntSushi/toml"
+	"encoding/json"
+	"os"
 )
 
 // Load opens the named file for reading. If successful, the manifest is returned.
 func Load(name string) (*Manifest, error) {
 	mfst := New()
-	if _, err := toml.DecodeFile(name, mfst); err != nil {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if err := json.NewDecoder(f).Decode(&mfst); err != nil {
 		return nil, err
 	}
 	return mfst, nil

--- a/pkg/duffle/manifest/manifest.go
+++ b/pkg/duffle/manifest/manifest.go
@@ -9,19 +9,19 @@ import (
 	"github.com/technosophos/moniker"
 )
 
-// Manifest represents a duffle.toml
+// Manifest represents a duffle manifest.
 type Manifest struct {
-	Name        string                                `toml:"name,omitempty"`
-	Components  map[string]*Component                 `toml:"components,omitempty"`
-	Parameters  map[string]bundle.ParameterDefinition `toml:"parameters,omitempty"`
-	Credentials map[string]bundle.CredentialLocation  `toml:"credentials,omitempty"`
+	Name        string                                `json:"name,omitempty"`
+	Components  map[string]*Component                 `json:"components,omitempty"`
+	Parameters  map[string]bundle.ParameterDefinition `json:"parameters,omitempty"`
+	Credentials map[string]bundle.CredentialLocation  `json:"credentials,omitempty"`
 }
 
 // Component represents a component of a CNAB bundle
 type Component struct {
-	Name          string            `toml:"name,omitempty"`
-	Builder       string            `toml:"builder,omitempty"`
-	Configuration map[string]string `toml:"configuration,omitempty"`
+	Name          string            `json:"name,omitempty"`
+	Builder       string            `json:"builder,omitempty"`
+	Configuration map[string]string `json:"configuration,omitempty"`
 }
 
 // New creates a new manifest with the Environments intialized.


### PR DESCRIPTION
This consolidates the input and output of `duffle build` to one format: JSON. Parameters are still accepted as TOML.

related to #204

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>