### PR TITLE
docs: begin spec

### DIFF
--- a/docs/specs/cnab/README.md
+++ b/docs/specs/cnab/README.md
@@ -1,0 +1,18 @@
+# Cloud Native Application Bundles (CNAB)
+
+## CNAB Package Specification
+
+This document describes the CNAB (Cloud Native Application Bundles) package format.
+
+A CNAB bundle consists of:
+- A [bundle.json file]
+- An [invocation image]
+
+Bundles can be packaged in [thin] or [thick] formats, and can be stored and served from [bundle repositories].
+
+## Table of Contents
+
+
+## Conventions Used in This Document
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/info/rfc2119) and [RFC8174](https://www.rfc-editor.org/info/rfc8174) when, and only when, they appear in all capitals, as shown here.


### PR DESCRIPTION
This is the placeholder document for beginning the work on a formal CNAB specification. I'm scaffolding this out so that I can ask @vbatts for some input on how to start this process. I'm trying to use the OCI spec as a starting point.