### PR TITLE
Redact credential values by default in duffle show

### DIFF
--- a/cmd/duffle/credential_show_test.go
+++ b/cmd/duffle/credential_show_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/deis/duffle/pkg/credentials"
+)
+
+func TestPrintCredentials(t *testing.T) {
+	cs := &credentials.CredentialSet{
+		Name: "foo",
+		Credentials: []credentials.CredentialStrategy{
+			{
+				Name:        "password",
+				Source:      credentials.Source{Value: "TOPSECRET"},
+				Destination: credentials.Destination{EnvVar: "PASSWORD"},
+			},
+			{
+				Name:        "another-password",
+				Destination: credentials.Destination{Value: "TOPSECRET"},
+			},
+			{
+				Name:        "kubeconfig",
+				Source:      credentials.Source{Path: "/root/.kube/config"},
+				Destination: credentials.Destination{Path: "/root/.kube/config"},
+			},
+			{
+				Name:        "some-setting",
+				Source:      credentials.Source{EnvVar: "MYSETTING"},
+				Destination: credentials.Destination{EnvVar: "MYSETTING"},
+			},
+		},
+	}
+
+	testcases := []struct {
+		name       string
+		unredacted bool
+		output     string
+	}{
+		{name: "reacted", unredacted: false, output: `name: foo
+credentials:
+- destination:
+    env: PASSWORD
+  name: password
+  source:
+    value: REDACTED
+- destination:
+    value: REDACTED
+  name: another-password
+  source: {}
+- destination:
+    path: /root/.kube/config
+  name: kubeconfig
+  source:
+    path: /root/.kube/config
+- destination:
+    env: MYSETTING
+  name: some-setting
+  source:
+    env: MYSETTING
+`},
+		{name: "unredacted", unredacted: true, output: `name: foo
+credentials:
+- destination:
+    env: PASSWORD
+  name: password
+  source:
+    value: TOPSECRET
+- destination:
+    value: TOPSECRET
+  name: another-password
+  source: {}
+- destination:
+    path: /root/.kube/config
+  name: kubeconfig
+  source:
+    path: /root/.kube/config
+- destination:
+    env: MYSETTING
+  name: some-setting
+  source:
+    env: MYSETTING
+`},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			show := &credentialShowCmd{
+				out:        output,
+				unredacted: tc.unredacted,
+			}
+
+			err := show.printCredentials(*cs)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := tc.output
+			got := output.String()
+			if want != got {
+				t.Fatalf("expected credentials output. WANT:\n%q\n\nGOT:\n%q\n", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a `--unredacted` flag to duffle credentials show, which is false by default. Now any values in a credential set print as REDACTED by default. To view the secret data, specify the `--unredacted` flag.

```console
$ duffle credentials show helloworld
name: helloworld
credentials:
- destination:
    path: pquux
  name: quux
  source:
    value: REDACTED

$ duffle credentials show helloworld --unredacted
name: helloworld
credentials:
- destination:
    path: pquux
  name: quux
  source:
    value: TOPSECRET_PASSWORD
```

Closes #188 