### PR TITLE
shorten the short help text

### DIFF
--- a/cmd/duffle/pull.go
+++ b/cmd/duffle/pull.go
@@ -18,7 +18,7 @@ Example:
 
 	cmd := &cobra.Command{
 		Use:   "pull",
-		Short: usage,
+		Short: "pulls a CNAB bundle from a repository",
 		Long:  usage,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path, err := getBundleFile(args[0])


### PR DESCRIPTION
fixes an issue where `duffle help` displays the full long description of
`duffle pull`.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>

closes #278