### PR TITLE
Updated credential_generate.go to replace error message

### DIFF
--- a/cmd/duffle/main_test.go
+++ b/cmd/duffle/main_test.go
@@ -10,10 +10,10 @@ import (
 func TestIsPathy(t *testing.T) {
 	is := assert.New(t)
 	for path, expect := range map[string]bool{
-		"foo":                                    false,
+		"foo": false,
 		filepath.Join("this", "is", "a", "path"): true,
-		"foo.yaml":                               false,
-		filepath.Join("..", "foo.yaml"):          true,
+		"foo.yaml":                      false,
+		filepath.Join("..", "foo.yaml"): true,
 	} {
 		is.Equal(expect, isPathy(path), "Expected %t, for %s", expect, path)
 	}


### PR DESCRIPTION
The command defined in credential_generate.go reuses the bundleFileOrArg2 function from install.go. That function has a couple of install references embedded within it. 

This PR introduces a new function for the `credentials generate` command with updated wording.

I also fixed the error from `make lint` with `cmd/duffle/main_test.go` being not goimported

Fixes #282 