### PR TITLE
Rationalise style of help strings

### DIFF
--- a/cmd/duffle/build.go
+++ b/cmd/duffle/build.go
@@ -27,7 +27,7 @@ import (
 )
 
 const buildDesc = `
-This command builds a CNAB bundle.
+Builds a CNAB bundle.
 `
 
 const (
@@ -59,7 +59,7 @@ func newBuildCmd(out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "build [path]",
-		Short: "builds a CNAB bundle",
+		Short: "build a CNAB bundle",
 		Long:  buildDesc,
 		PersistentPreRun: func(c *cobra.Command, args []string) {
 			build.dockerClientOptions.Common.SetDefaultOptions(f)

--- a/cmd/duffle/credentials.go
+++ b/cmd/duffle/credentials.go
@@ -7,7 +7,7 @@ import (
 )
 
 const credentialDesc = `
-Manage credential sets
+Manages credential sets.
 `
 
 func newCredentialsCmd(w io.Writer) *cobra.Command {

--- a/cmd/duffle/init.go
+++ b/cmd/duffle/init.go
@@ -45,7 +45,7 @@ func newInitCmd(w io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "sets up local environment to work with duffle",
+		Short: "set up local environment to work with duffle",
 		Long:  initDesc,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -22,7 +22,7 @@ import (
 )
 
 func newInstallCmd() *cobra.Command {
-	const usage = `Install a CNAB bundle
+	const usage = `Installs a CNAB bundle.
 
 This installs a CNAB bundle with a specific installation name. Once the install is complete,
 this bundle can be referenced by installation name.

--- a/cmd/duffle/key.go
+++ b/cmd/duffle/key.go
@@ -7,7 +7,7 @@ import (
 )
 
 const keyDesc = `
-Manage OpenPGP keys, signatures, and attestations.
+Manages OpenPGP keys, signatures, and attestations.
 `
 
 // TODO

--- a/cmd/duffle/pull.go
+++ b/cmd/duffle/pull.go
@@ -8,9 +8,7 @@ import (
 )
 
 func newPullCmd(w io.Writer) *cobra.Command {
-	const usage = `pulls a CNAB bundle from a repository
-
-This command pulls a CNAB bundle into the cache without installing it.
+	const usage = `Pulls a CNAB bundle into the cache without installing it.
 
 Example:
 	$ duffle pull duffle/example:0.1.0
@@ -18,7 +16,7 @@ Example:
 
 	cmd := &cobra.Command{
 		Use:   "pull",
-		Short: "pulls a CNAB bundle from a repository",
+		Short: "pull a CNAB bundle from a repository",
 		Long:  usage,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path, err := getBundleFile(args[0])

--- a/cmd/duffle/push.go
+++ b/cmd/duffle/push.go
@@ -19,13 +19,13 @@ type pushCmd struct {
 }
 
 func newPushCmd(out io.Writer) *cobra.Command {
-	const usage = `pushes a CNAB bundle to a repository`
+	const usage = `Pushes a CNAB bundle to a repository.`
 
 	var push = &pushCmd{out: out}
 
 	cmd := &cobra.Command{
 		Use:   "push",
-		Short: usage,
+		Short: "push a CNAB bundle to a repository",
 		Long:  usage,
 		RunE: func(_ *cobra.Command, args []string) error {
 			push.home = home.Home(homePath())

--- a/cmd/duffle/status.go
+++ b/cmd/duffle/status.go
@@ -14,7 +14,7 @@ import (
 
 func newStatusCmd(w io.Writer) *cobra.Command {
 	const short = "get the status of an installation"
-	const long = `Get the status of an existing installation.
+	const long = `Gets the status of an existing installation.
 
 Given an installation name, execute the status task for this. A status
 action will restart the CNAB image and ask it to query for status. For that

--- a/cmd/duffle/uninstall.go
+++ b/cmd/duffle/uninstall.go
@@ -9,7 +9,7 @@ import (
 	"github.com/deis/duffle/pkg/action"
 )
 
-const usage = `This command will uninstall an installation of a CNAB bundle.
+const usage = `Uninstalls an installation of a CNAB bundle.
 
 When using '--parameters' or '--set', the uninstall command will replace the old
 parameters with the new ones supplied (even if the new set is an empty set). If neither

--- a/cmd/duffle/upgrade.go
+++ b/cmd/duffle/upgrade.go
@@ -9,8 +9,8 @@ import (
 	"github.com/deis/duffle/pkg/action"
 )
 
-const upgradeUsage = `This command will perform the upgrade action in the CNAB bundle`
-const upgradeLong = `Upgrade an existing application.
+const upgradeUsage = `perform the upgrade action in the CNAB bundle`
+const upgradeLong = `Upgrades an existing application.
 
 An upgrade can do the following:
 

--- a/cmd/duffle/version.go
+++ b/cmd/duffle/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newVersionCmd(w io.Writer) *cobra.Command {
-	const usage = `prints current version of the Duffle CLI`
+	const usage = `print current version of the Duffle CLI`
 
 	cmd := &cobra.Command{
 		Use:   "version",


### PR DESCRIPTION
Fixes #287.

Previous help strings:

```
  build       builds a CNAB bundle
  credentials manage credential sets
  help        Help about any command
  init        sets up local environment to work with duffle
  install     install a CNAB bundle
  key         manage keys
  list        list installed apps
  pull        pulls a CNAB bundle from a repository
  push        pushes a CNAB bundle to a repository
  search      perform a fuzzy search on available bundles
  status      get the status of an installation
  uninstall   uninstall CNAB installation
  upgrade     This command will perform the upgrade action in the CNAB bundle
  version     prints current version of the Duffle CLI
```

Updated help strings - all lower case and infinitive (except `help` which seems not to be defined in our program... perhaps in Cobra itself?):

```
  build       build a CNAB bundle
  credentials manage credential sets
  help        Help about any command
  init        set up local environment to work with duffle
  install     install a CNAB bundle
  key         manage keys
  list        list installed apps
  pull        pull a CNAB bundle from a repository
  push        push a CNAB bundle to a repository
  search      perform a fuzzy search on available bundles
  status      get the status of an installation
  uninstall   uninstall CNAB installation
  upgrade     perform the upgrade action in the CNAB bundle
  version     print current version of the Duffle CLI
```
```
