### PR TITLE
remove `library` prefix when no prefix is found

### DIFF
--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -250,16 +249,10 @@ func getBundleRepoURL(bundleName string, home home.Home) (*url.URL, error) {
 		proto = parts[0]
 	}
 
-	refPath := reference.Path(ref)
-	if len(strings.Split(refPath, "/")) == 1 {
-		// this should go into the default library
-		refPath = path.Join("library", refPath)
-	}
-
 	url := &url.URL{
 		Scheme: proto,
 		Host:   reference.Domain(ref),
-		Path:   fmt.Sprintf("repositories/%s/tags/%s", refPath, ref.Tag()),
+		Path:   fmt.Sprintf("repositories/%s/tags/%s", reference.Path(ref), ref.Tag()),
 	}
 	return url, nil
 }

--- a/cmd/duffle/install_test.go
+++ b/cmd/duffle/install_test.go
@@ -32,8 +32,8 @@ func TestGetBundleFile(t *testing.T) {
 		},
 		{
 			Name:             "namespaced helloazure",
-			File:             "https://hub.cnlabs.io/bacongobbler/helloazure:0.1.0",
-			ExpectedFilepath: filepath.Join(testHome.Cache(), "bacongobbler-helloazure-0.1.0.json"),
+			File:             "https://hub.cnlabs.io/library/helloazure:0.1.0",
+			ExpectedFilepath: filepath.Join(testHome.Cache(), "helloazure-0.1.0.json"),
 		},
 	}
 


### PR DESCRIPTION
With this change, any bundles being pushed to the root will be published
there rather than at library/{name}.

This also fixes a CLI test error where a bundle that used to exist at hub.cnlabs.io no longer exists (I deleted it), so I re-uploaded it to `library/helloworld` to make tests pass again.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>