### PR TITLE
Add injected-files into invocation images

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/deis/duffle/pkg/bundle"
-
 	"github.com/deis/duffle/pkg/claim"
 	"github.com/deis/duffle/pkg/credentials"
 	"github.com/deis/duffle/pkg/driver"
@@ -42,6 +41,10 @@ func selectInvocationImage(d driver.Driver, c *claim.Claim) (bundle.InvocationIm
 
 func opFromClaim(action string, c *claim.Claim, ii bundle.InvocationImage, creds credentials.Set, w io.Writer) *driver.Operation {
 	env, files := creds.Flatten()
+	for k, v := range c.Files {
+		files[c.Bundle.Files[k].Path] = v
+	}
+
 	return &driver.Operation{
 		Action:       action,
 		Installation: c.Name,

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -76,6 +76,13 @@ type CredentialLocation struct {
 	EnvironmentVariable string `json:"env" toml:"env"`
 }
 
+// FileLocation contains the location of a file the the invocation image
+// can use
+type FileLocation struct {
+	Path     string `json:"path" toml:"path"`
+	Required bool   `json:"required" toml:"required"`
+}
+
 // Maintainer describes a code maintainer of a bundle
 type Maintainer struct {
 	// Name is a user name or organization name
@@ -97,6 +104,7 @@ type Bundle struct {
 	Images           []Image                        `json:"images" toml:"images"`
 	Parameters       map[string]ParameterDefinition `json:"parameters" toml:"parameters"`
 	Credentials      map[string]CredentialLocation  `json:"credentials" toml:"credentials"`
+	Files            map[string]FileLocation        `json:"files" toml:"files"`
 }
 
 // ValuesOrDefaults returns parameter values or the default parameter values

--- a/pkg/claim/claim.go
+++ b/pkg/claim/claim.go
@@ -42,6 +42,7 @@ type Claim struct {
 	Bundle     *bundle.Bundle         `json:"bundle"`
 	Result     Result                 `json:"result"`
 	Parameters map[string]interface{} `json:"parameters"`
+	Files      map[string]string      `json:"files"`
 }
 
 // ValidName is a regular expression that indicates whether a name is a valid claim name.


### PR DESCRIPTION
This allows invocation images requiring settings files to work
correctly.
e-g: for docker-app invocation image, you can use settings files to
provide templated parameters. This is important, as this invocation
image as a setting management that is case-sensitive, and depending on
which docker-app package you want to deploy, the settings to pass can be
different.
This would also make it easier to create a generic Helm invocation image
(e.g.: we can mount settings files, or even an helm chart in tarball
format to the invocation image)

Related to #294