### PR TITLE
feat: save signed bundle to file

### DIFF
--- a/cmd/duffle/key_sign_test.go
+++ b/cmd/duffle/key_sign_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeySign(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "duffle-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outfile := tmp.Name()
+	defer os.Remove(outfile)
+
+	bundlejson := filepath.Join("..", "..", "tests", "testdata", "bundles", "foo.json")
+	keyring := filepath.Join("..", "..", "pkg", "signature", "testdata", "keyring.gpg")
+	identity := "test2@example.com"
+
+	if err := signFile(bundlejson, keyring, identity, outfile, false); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadFile(outfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig := string(data)
+	is := assert.New(t)
+	is.Contains(sig, "-----BEGIN PGP SIGNATURE-----")
+}


### PR DESCRIPTION
This changes the behavior of 'duffle key sign', saving the output to a file instead of writing it to STDOUT.