### PR TITLE
Added test for claimstore and ensured the use of empty slices instead of nil ones

### DIFF
--- a/pkg/claim/claimstore.go
+++ b/pkg/claim/claimstore.go
@@ -54,7 +54,7 @@ func (s Store) Read(name string) (Claim, error) {
 
 // ReadAll retrieves all the claims
 func (s Store) ReadAll() ([]Claim, error) {
-	claims := []Claim{}
+	claims := make([]Claim, 0)
 
 	list, err := s.backingStore.List()
 	if err != nil {

--- a/pkg/claim/claimstore_test.go
+++ b/pkg/claim/claimstore_test.go
@@ -85,3 +85,42 @@ func TestCanUpdate(t *testing.T) {
 		t.Errorf("Expected to read back new revision, got old revision %s", rev)
 	}
 }
+
+func TestReadAll(t *testing.T) {
+	is := assert.New(t)
+
+	tempDir, err := ioutil.TempDir("", "duffletest")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	storeDir := filepath.Join(tempDir, "claimstore")
+	store := NewClaimStore(crud.NewFileSystemStore(storeDir, "json"))
+
+	claim, err := New("foo")
+	is.NoError(err)
+	claim.Bundle = &bundle.Bundle{Name: "foobundle", Version: "0.1.0"}
+
+	is.NoError(store.Store(*claim), "Failed to store: %s", err)
+
+	claim2, err := New("bar")
+	is.NoError(err)
+	claim2.Bundle = &bundle.Bundle{Name: "barbundle", Version: "0.1.0"}
+
+	is.NoError(store.Store(*claim2), "Failed to store: %s", err)
+
+	claim3, err := New("baz")
+	is.NoError(err)
+	claim3.Bundle = &bundle.Bundle{Name: "bazbundle", Version: "0.1.0"}
+
+	is.NoError(store.Store(*claim3), "Failed to store: %s", err)
+
+	claims, err := store.ReadAll()
+	is.NoError(err, "Failed to read claims: %s", err)
+
+	is.Len(claims, 3)
+	is.Equal("foo", claim.Name)
+	is.Equal("bar", claim2.Name)
+	is.Equal("baz", claim3.Name)
+}

--- a/pkg/utils/crud/filesystem.go
+++ b/pkg/utils/crud/filesystem.go
@@ -92,7 +92,7 @@ func (s fileSystemStore) ensure() error {
 }
 
 func (s fileSystemStore) storageFiles(files []os.FileInfo) []os.FileInfo {
-	var result []os.FileInfo
+	result := make([]os.FileInfo, 0)
 	ext := "." + s.fileExtension
 	for _, file := range files {
 		if !file.IsDir() && filepath.Ext(file.Name()) == ext {
@@ -103,7 +103,7 @@ func (s fileSystemStore) storageFiles(files []os.FileInfo) []os.FileInfo {
 }
 
 func names(files []os.FileInfo) []string {
-	var result []string
+	result := make([]string, 0)
 	for _, file := range files {
 		result = append(result, name(file.Name()))
 	}


### PR DESCRIPTION
@technosophos I thought it'd be just better that we continued using empty slices as opposed to nil ones which I had introduced in my previous PR. This way, we were more consistent in the way we dealt with the filesystem logic. 

I have also added a UT for claim store ReadAll()