### PR TITLE
feat: add 'duffle run' command

### DIFF
--- a/cmd/duffle/root.go
+++ b/cmd/duffle/root.go
@@ -43,6 +43,7 @@ func newRootCmd(outputRedirect io.Writer) *cobra.Command {
 	cmd.AddCommand(newStatusCmd(outLog))
 	cmd.AddCommand(newUninstallCmd())
 	cmd.AddCommand(newUpgradeCmd())
+	cmd.AddCommand(newRunCmd(outLog))
 	cmd.AddCommand(newCredentialsCmd(outLog))
 	cmd.AddCommand(newKeyCmd(outLog))
 

--- a/cmd/duffle/run.go
+++ b/cmd/duffle/run.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/deis/duffle/pkg/action"
+	"github.com/deis/duffle/pkg/claim"
+)
+
+func newRunCmd(w io.Writer) *cobra.Command {
+	const short = "run a target in the bundle"
+	const long = `Run an arbitrary target in the bundle.
+
+Some CNAB bundles may declare custom targets in addition to install, upgrade, and uninstall.
+This command can be used to execute those targets.
+
+The 'run' command takes a ACTION and a RELEASE NAME:
+
+  $ duffle run migrate my-release
+
+This will start the invocation image for the release in 'my-release', and then send
+the action 'migrate'. If the invocation image does not have a 'migrate' action, it
+may return an error.
+
+Custom actions can only be executed on releases (already-installed bundles).
+
+Credentials and parameters may be passed to the bundle during a target action.
+`
+	var (
+		driver          string
+		credentialsFile string
+		valuesFile      string
+		setParams       []string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "run ACTION RELEASE_NAME",
+		Aliases: []string{"exec"},
+		Short:   short,
+		Long:    long,
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := args[0]
+			claimName := args[1]
+			storage := claimStorage()
+			c, err := storage.Read(claimName)
+			if err != nil {
+				if err == claim.ErrClaimNotFound {
+					return fmt.Errorf("Bundle installation '%s' not found", claimName)
+				}
+				return err
+			}
+
+			creds, err := loadCredentials(credentialsFile, c.Bundle)
+			if err != nil {
+				return err
+			}
+
+			driverImpl, err := prepareDriver(driver)
+			if err != nil {
+				return err
+			}
+
+			// Override parameters only if some are set.
+			if valuesFile != "" || len(setParams) > 0 {
+				c.Parameters, err = calculateParamValues(c.Bundle, valuesFile, setParams)
+				if err != nil {
+					return err
+				}
+			}
+
+			action := &action.RunCustom{
+				Driver: driverImpl,
+				Action: target,
+			}
+
+			fmt.Printf("Executing custom action %q for release %q", target, claimName)
+			err = action.Run(&c, creds, cmd.OutOrStdout())
+			if actionDef := c.Bundle.Actions[target]; !actionDef.Modifies {
+				// Do not store a claim for non-mutating actions.
+				return err
+			}
+
+			err2 := storage.Store(c)
+			if err != nil {
+				return fmt.Errorf("run failed: %s", err)
+			}
+			return err2
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVarP(&driver, "driver", "d", "docker", "Specify a driver name")
+	flags.StringVarP(&credentialsFile, "credentials", "c", "", "Specify a set of credentials to use inside the CNAB bundle")
+	flags.StringVarP(&valuesFile, "parameters", "p", "", "Specify file containing parameters. Formats: toml, MORE SOON")
+	flags.StringArrayVarP(&setParams, "set", "s", []string{}, "Set individual parameters as NAME=VALUE pairs")
+
+	return cmd
+}

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -46,6 +46,9 @@ func mockBundle() *bundle.Bundle {
 				Path: "secret_two",
 			},
 		},
+		Actions: map[string]bundle.Action{
+			"test": {Modifies: true},
+		},
 	}
 
 }

--- a/pkg/action/run_custom.go
+++ b/pkg/action/run_custom.go
@@ -1,0 +1,67 @@
+package action
+
+import (
+	"errors"
+	"io"
+
+	"github.com/deis/duffle/pkg/claim"
+	"github.com/deis/duffle/pkg/credentials"
+	"github.com/deis/duffle/pkg/driver"
+)
+
+var (
+	// ErrBlockedAction indicates that the requested action was not allowed.
+	ErrBlockedAction = errors.New("action not allowed")
+	// ErrUndefinedAction indicates that a bundle does not define this action.
+	ErrUndefinedAction = errors.New("action not defined for bundle")
+)
+
+// RunCustom allows the execution of an arbitrary target in a CNAB bundle.
+type RunCustom struct {
+	Driver driver.Driver
+	Action string
+}
+
+// blockedActions is a list of actions that cannot be run as custom.
+//
+// This prevents accidental circumvention of standard behavior.
+var blockedActions = map[string]struct{}{"install": {}, "uninstall": {}, "upgrade": {}}
+
+// Run executes a status action in an image
+func (i *RunCustom) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error {
+	if _, ok := blockedActions[i.Action]; ok {
+		return ErrBlockedAction
+	}
+
+	actionDef, ok := c.Bundle.Actions[i.Action]
+	if !ok {
+		return ErrUndefinedAction
+	}
+
+	invocImage, err := selectInvocationImage(i.Driver, c)
+	if err != nil {
+		return err
+	}
+
+	op, err := opFromClaim(i.Action, c, invocImage, creds, w)
+	if err != nil {
+		return err
+	}
+
+	err = i.Driver.Run(op)
+
+	// If this action says it does not modify the release, then we don't track
+	// it in the claim. Otherwise, we do.
+	if !actionDef.Modifies {
+		return err
+	}
+
+	status := claim.StatusSuccess
+	if err != nil {
+		c.Result.Message = err.Error()
+		status = claim.StatusFailure
+	}
+
+	c.Update(i.Action, status)
+	return err
+}

--- a/pkg/action/run_custom_test.go
+++ b/pkg/action/run_custom_test.go
@@ -1,0 +1,47 @@
+package action
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/deis/duffle/pkg/bundle"
+	"github.com/deis/duffle/pkg/claim"
+	"github.com/deis/duffle/pkg/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunCustom(t *testing.T) {
+	out := ioutil.Discard
+	is := assert.New(t)
+
+	rc := &RunCustom{
+		Driver: &driver.DebugDriver{},
+		Action: "test",
+	}
+	c := &claim.Claim{
+		Created:    time.Time{},
+		Modified:   time.Time{},
+		Name:       "runcustom",
+		Revision:   "revision",
+		Bundle:     mockBundle(),
+		Parameters: map[string]interface{}{},
+	}
+
+	if err := rc.Run(c, mockSet, out); err != nil {
+		t.Fatal(err)
+	}
+	is.Equal(claim.StatusSuccess, c.Result.Status)
+	is.Equal("test", c.Result.Action)
+
+	// Make sure we don't allow forbidden custom actions
+	rc.Action = "install"
+	is.Error(rc.Run(c, mockSet, out))
+
+	// Get rid of custom actions, and this should fail
+	rc.Action = "test"
+	c.Bundle.Actions = map[string]bundle.Action{}
+	if err := rc.Run(c, mockSet, out); err == nil {
+		t.Fatal("Unknown action should fail")
+	}
+}

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -93,6 +93,14 @@ type Maintainer struct {
 	URL string `json:"url" toml:"url"`
 }
 
+// Action describes a custom (non-core) action.
+type Action struct {
+	// Modifies indicates whether this action modifies the release.
+	//
+	// If it is possible that an action modify a release, this must be set to true.
+	Modifies bool
+}
+
 // Bundle is a CNAB metadata document
 type Bundle struct {
 	Name             string                         `json:"name" toml:"name"`
@@ -102,6 +110,7 @@ type Bundle struct {
 	Maintainers      []Maintainer                   `json:"maintainers" toml:"maintainers"`
 	InvocationImages []InvocationImage              `json:"invocationImages" toml:"invocationImages"`
 	Images           []Image                        `json:"images" toml:"images"`
+	Actions          map[string]Action              `json:"actions,omitempty" toml:"actions,omitempty"`
 	Parameters       map[string]ParameterDefinition `json:"parameters" toml:"parameters"`
 	Credentials      map[string]CredentialLocation  `json:"credentials" toml:"credentials"`
 	Files            map[string]FileLocation        `json:"files" toml:"files"`


### PR DESCRIPTION
This adds a new 'duffle run' command, as well as a description (in bundle.json) of what additional actions are available.

To test:

- Modify bundle.json to include an 'actions' section
- Run 'duffle run ACTION RELEASE'

Runs are allowed to have parameters and credentials. They can only be run on bundles that have already been installed. If they modify the release, they MUST set 'modifes: true' in the bundle.json definition