### PR TITLE
Adding local option to goimports prefixes

### DIFF
--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -16,6 +16,7 @@ import (
 	"github.com/deis/duffle/pkg/duffle/home"
 	"github.com/deis/duffle/pkg/loader"
 	"github.com/deis/duffle/pkg/reference"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/duffle/key_list.go
+++ b/cmd/duffle/key_list.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/deis/duffle/pkg/duffle/home"
 	"github.com/deis/duffle/pkg/signature"
-	"github.com/gosuri/uitable"
 
+	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/duffle/upgrade.go
+++ b/cmd/duffle/upgrade.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/deis/duffle/pkg/action"
+
 	"github.com/spf13/cobra"
 )
 

--- a/golangci.yml
+++ b/golangci.yml
@@ -13,3 +13,7 @@ linters:
   - unused
   - deadcode
   - govet
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/deis/duffle


### PR DESCRIPTION
@technosophos : Adding this option because it was not supported in golang-ci previously and this option was supported in the retired gometalinter config.

With this PR, we will have achieved functional equivalence with the previous gometalinter check :)