### PR TITLE
feat: allow multiple credentials and merge them

### DIFF
--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -54,13 +54,13 @@ For unpublished CNAB bundles, you can also load the bundle.json directly:
     $ duffle install dev_bundle -f path/to/bundle.json
 `
 	var (
-		installDriver   string
-		credentialsFile string
-		valuesFile      string
-		bundleFile      string
-		setParams       []string
-		insecure        bool
-		setFiles        []string
+		installDriver    string
+		credentialsFiles []string
+		valuesFile       string
+		bundleFile       string
+		setParams        []string
+		insecure         bool
+		setFiles         []string
 
 		installationName string
 		bun              *bundle.Bundle
@@ -91,7 +91,7 @@ For unpublished CNAB bundles, you can also load the bundle.json directly:
 				return err
 			}
 
-			creds, err := loadCredentials(credentialsFile, bun)
+			creds, err := loadCredentials(credentialsFiles, bun)
 			if err != nil {
 				return err
 			}
@@ -128,10 +128,10 @@ For unpublished CNAB bundles, you can also load the bundle.json directly:
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
-	flags.StringVarP(&credentialsFile, "credentials", "c", "", "Specify a set of credentials to use inside the CNAB bundle")
 	flags.StringVarP(&installDriver, "driver", "d", "docker", "Specify a driver name")
 	flags.StringVarP(&valuesFile, "parameters", "p", "", "Specify file containing parameters. Formats: toml, MORE SOON")
 	flags.StringVarP(&bundleFile, "file", "f", "", "Bundle file to install")
+	flags.StringArrayVarP(&credentialsFiles, "credentials", "c", []string{}, "Specify a set of credentials to use inside the CNAB bundle")
 	flags.StringArrayVarP(&setParams, "set", "s", []string{}, "Set individual parameters as NAME=VALUE pairs")
 	flags.StringArrayVarP(&setFiles, "set-file", "i", []string{}, "Set individual parameters from file content as NAME=SOURCE-PATH pairs")
 	return cmd

--- a/cmd/duffle/status.go
+++ b/cmd/duffle/status.go
@@ -21,8 +21,8 @@ action will restart the CNAB image and ask it to query for status. For that
 reason, it may need the same credentials used to install.
 `
 	var (
-		statusDriver    string
-		credentialsFile string
+		statusDriver     string
+		credentialsFiles []string
 	)
 
 	cmd := &cobra.Command{
@@ -57,7 +57,7 @@ reason, it may need the same credentials used to install.
 			table.AddRow("Last Action Message:", c.Result.Message)
 			fmt.Println(table)
 
-			creds, err := loadCredentials(credentialsFile, c.Bundle)
+			creds, err := loadCredentials(credentialsFiles, c.Bundle)
 			if err != nil {
 				return err
 			}
@@ -74,7 +74,7 @@ reason, it may need the same credentials used to install.
 		},
 	}
 	cmd.Flags().StringVarP(&statusDriver, "driver", "d", "docker", "Specify a driver name")
-	cmd.Flags().StringVarP(&credentialsFile, "credentials", "c", "", "Specify a set of credentials to use inside the CNAB bundle")
+	cmd.Flags().StringArrayVarP(&credentialsFiles, "credentials", "c", []string{}, "Specify a set of credentials to use inside the CNAB bundle")
 
 	return cmd
 }

--- a/cmd/duffle/uninstall.go
+++ b/cmd/duffle/uninstall.go
@@ -32,8 +32,8 @@ func newUninstallCmd() *cobra.Command {
 	uc := &uninstallCmd{}
 
 	var (
-		credentialsFile string
-		bundleFile      string
+		credentialsFiles []string
+		bundleFile       string
 	)
 
 	cmd := &cobra.Command{
@@ -51,13 +51,13 @@ func newUninstallCmd() *cobra.Command {
 				uc.bundleFile = bundleFile
 			}
 
-			return uc.uninstall(credentialsFile)
+			return uc.uninstall(credentialsFiles)
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.StringVarP(&uninstallDriver, "driver", "d", "docker", "Specify a driver name")
-	flags.StringVarP(&credentialsFile, "credentials", "c", "", "Specify a set of credentials to use inside the CNAB bundle")
+	flags.StringArrayVarP(&credentialsFiles, "credentials", "c", []string{}, "Specify a set of credentials to use inside the CNAB bundle")
 	flags.StringVarP(&bundleFile, "file", "f", "", "bundle file to install")
 	flags.StringVarP(&uc.valuesFile, "parameters", "p", "", "Specify file containing parameters. Formats: toml, MORE SOON")
 	flags.StringArrayVarP(&uc.setParams, "set", "s", []string{}, "set individual parameters as NAME=VALUE pairs")
@@ -66,7 +66,7 @@ func newUninstallCmd() *cobra.Command {
 	return cmd
 }
 
-func (un *uninstallCmd) uninstall(credentialsFile string) error {
+func (un *uninstallCmd) uninstall(credentialsFiles []string) error {
 
 	claim, err := claimStorage().Read(un.name)
 	if err != nil {
@@ -99,7 +99,7 @@ func (un *uninstallCmd) uninstall(credentialsFile string) error {
 		return fmt.Errorf("could not prepare driver: %s", err)
 	}
 
-	creds, err := loadCredentials(credentialsFile, claim.Bundle)
+	creds, err := loadCredentials(credentialsFiles, claim.Bundle)
 	if err != nil {
 		return fmt.Errorf("could not load credentials: %s", err)
 	}

--- a/cmd/duffle/upgrade.go
+++ b/cmd/duffle/upgrade.go
@@ -39,8 +39,8 @@ func newUpgradeCmd() *cobra.Command {
 	uc := &upgradeCmd{}
 
 	var (
-		credentialsFile string
-		bundleFile      string
+		credentialsFiles []string
+		bundleFile       string
 	)
 
 	cmd := &cobra.Command{
@@ -59,14 +59,14 @@ func newUpgradeCmd() *cobra.Command {
 				return err
 			}
 
-			return uc.upgrade(credentialsFile, bundleFile)
+			return uc.upgrade(credentialsFiles, bundleFile)
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.StringVarP(&bundleFile, "file", "f", "", "Set the bundle file to use for upgrading")
 	flags.StringVarP(&upgradeDriver, "driver", "d", "docker", "Specify a driver name")
-	flags.StringVarP(&credentialsFile, "credentials", "c", "", "Specify a set of credentials to use inside the CNAB bundle")
+	flags.StringArrayVarP(&credentialsFiles, "credentials", "c", []string{}, "Specify a set of credentials to use inside the CNAB bundle")
 	flags.StringVarP(&uc.valuesFile, "parameters", "p", "", "Specify file containing parameters. Formats: toml, MORE SOON")
 	flags.StringArrayVarP(&uc.setParams, "set", "s", []string{}, "Set individual parameters as NAME=VALUE pairs")
 	flags.BoolVarP(&uc.insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
@@ -74,7 +74,7 @@ func newUpgradeCmd() *cobra.Command {
 	return cmd
 }
 
-func (up *upgradeCmd) upgrade(credentialsFile, bundleFile string) error {
+func (up *upgradeCmd) upgrade(credentialsFiles []string, bundleFile string) error {
 
 	claim, err := claimStorage().Read(up.name)
 	if err != nil {
@@ -95,7 +95,7 @@ func (up *upgradeCmd) upgrade(credentialsFile, bundleFile string) error {
 		return err
 	}
 
-	creds, err := loadCredentials(credentialsFile, claim.Bundle)
+	creds, err := loadCredentials(credentialsFiles, claim.Bundle)
 	if err != nil {
 		return err
 	}

--- a/cmd/duffle/upgrade_test.go
+++ b/cmd/duffle/upgrade_test.go
@@ -54,7 +54,7 @@ func TestUpgradePersistsClaim(t *testing.T) {
 		name: instClaim.Name,
 	}
 	up.Out = out
-	err = up.upgrade("", "")
+	err = up.upgrade([]string{}, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/credentials/credentialset.go
+++ b/pkg/credentials/credentialset.go
@@ -41,9 +41,9 @@ func (s Set) Expand(b *bundle.Bundle) (env, files map[string]string, err error) 
 // CredentialSet represents a collection of credentials
 type CredentialSet struct {
 	// Name is the name of the credentialset.
-	Name string
+	Name string `json:"name" yaml:"name"`
 	// Creadentials is a list of credential specs.
-	Credentials []CredentialStrategy
+	Credentials []CredentialStrategy `json:"credentials" yaml:"credentials"`
 }
 
 // Load a CredentialSet from a file at a given path.


### PR DESCRIPTION
This changes the behavior of the --credentials flag to allow a user to specify multiple credential sets. Credential sets are then merged in order.

Closes #203