### PR TITLE
fix compiler errors

### DIFF
--- a/cmd/duffle/run.go
+++ b/cmd/duffle/run.go
@@ -54,7 +54,7 @@ Credentials and parameters may be passed to the bundle during a target action.
 				return err
 			}
 
-			creds, err := loadCredentials(credentialsFile, c.Bundle)
+			creds, err := loadCredentials([]string{credentialsFile}, c.Bundle)
 			if err != nil {
 				return err
 			}
@@ -66,7 +66,7 @@ Credentials and parameters may be passed to the bundle during a target action.
 
 			// Override parameters only if some are set.
 			if valuesFile != "" || len(setParams) > 0 {
-				c.Parameters, err = calculateParamValues(c.Bundle, valuesFile, setParams)
+				c.Parameters, err = calculateParamValues(c.Bundle, valuesFile, setParams, []string{})
 				if err != nil {
 					return err
 				}

--- a/pkg/action/run_custom_test.go
+++ b/pkg/action/run_custom_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/deis/duffle/pkg/bundle"
 	"github.com/deis/duffle/pkg/claim"
 	"github.com/deis/duffle/pkg/driver"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRunCustom(t *testing.T) {


### PR DESCRIPTION
Not sure whether this is the right design or not, but it allows `make build` to work on master again.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>