### PR TITLE
Check if claim with the same name already exists before install

### DIFF
--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -77,6 +77,12 @@ For unpublished CNAB bundles, you can also load the bundle.json directly:
 			}
 			installationName = args[0]
 
+			// look in claims store for another claim with the same name
+			_, err = claimStorage().Read(installationName)
+			if err != claim.ErrClaimNotFound {
+				return fmt.Errorf("a claim with the name %v already exists. Execute `$ duffle claims show %v` to inspect it", installationName, installationName)
+			}
+
 			bun, err = loadBundle(bundleFile, insecure)
 			if err != nil {
 				return err


### PR DESCRIPTION
This PR checks for an existing claim with the same name - if found, it errors out.

closes #319 