### PR TITLE
Add claim/s list command

### DIFF
--- a/cmd/duffle/claims.go
+++ b/cmd/duffle/claims.go
@@ -25,6 +25,7 @@ func newClaimsCmd(w io.Writer) *cobra.Command {
 	}
 
 	cmd.AddCommand(newClaimsShowCmd(w))
+	cmd.AddCommand(newClaimListCmd(w))
 
 	return cmd
 }

--- a/cmd/duffle/claims_list.go
+++ b/cmd/duffle/claims_list.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+func newClaimListCmd(out io.Writer) *cobra.Command {
+	list := listCmd{out: out}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list available claims",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			l := &listCmd{out: out, long: list.long}
+			return l.run()
+		},
+	}
+
+	f := cmd.Flags()
+	f.BoolVarP(&list.long, "long", "l", false, "output longer listing format")
+
+	return cmd
+}


### PR DESCRIPTION
This PR adds a `claim/s list` command, that calls out to `duffle list`.

This is not necessarily the most elegant solution, but if `list` and `claim/s list` diverge in the future, we can decouple their implementations rather easily.
