### PR TITLE
getBundleFile support PGP signed bundles

### DIFF
--- a/cmd/duffle/credential_generate.go
+++ b/cmd/duffle/credential_generate.go
@@ -7,12 +7,11 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/deis/duffle/pkg/bundle"
 	"github.com/deis/duffle/pkg/credentials"
 	"github.com/deis/duffle/pkg/duffle/home"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const credentialGenerateHelp = `Generate credentials from a CNAB bundle
@@ -40,7 +39,7 @@ func newCredentialGenerateCmd(out io.Writer) *cobra.Command {
 		Short:   "generate a credentialset from a bundle",
 		Long:    credentialGenerateHelp,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			bf, err := getBundleFileFromCredentialsArg(args, bundleFile, out)
+			bf, err := getBundleFileFromCredentialsArg(args, bundleFile, out, insecure)
 			if err != nil {
 				return err
 			}
@@ -87,7 +86,7 @@ func genCredentialSet(name string, creds map[string]bundle.Location) credentials
 	return cs
 }
 
-func getBundleFileFromCredentialsArg(args []string, bundleFile string, w io.Writer) (string, error) {
+func getBundleFileFromCredentialsArg(args []string, bundleFile string, w io.Writer, insecure bool) (string, error) {
 	switch {
 	case len(args) < 1:
 		return "", errors.New("This command requires at least one argument: NAME (name for the credentialset). It also requires a BUNDLE (CNAB bundle name) or file (using -f)\nValid inputs:\n\t$ duffle credentials generate NAME BUNDLE\n\t$ duffle credentials generate NAME -f path-to-bundle.json")
@@ -96,7 +95,7 @@ func getBundleFileFromCredentialsArg(args []string, bundleFile string, w io.Writ
 	case len(args) < 2 && bundleFile == "":
 		return "", errors.New("required arguments are NAME (name for the credentialset) and BUNDLE (CNAB bundle name) or file")
 	case len(args) == 2:
-		return getBundleFile(args[1])
+		return getBundleFile(args[1], insecure)
 	}
 	return bundleFile, nil
 }

--- a/cmd/duffle/install_test.go
+++ b/cmd/duffle/install_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/deis/duffle/pkg/bundle"
 	"github.com/deis/duffle/pkg/duffle/home"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetBundleFile(t *testing.T) {
@@ -41,7 +40,7 @@ func TestGetBundleFile(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			filePath, err := getBundleFile(tc.File)
+			filePath, err := getBundleFile(tc.File, true)
 			if err != nil {
 				t.Error(err)
 			}

--- a/cmd/duffle/pull.go
+++ b/cmd/duffle/pull.go
@@ -3,7 +3,10 @@ package main
 import (
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 
+	"github.com/deis/duffle/pkg/duffle/home"
 	"github.com/spf13/cobra"
 )
 
@@ -13,20 +16,27 @@ func newPullCmd(w io.Writer) *cobra.Command {
 Example:
 	$ duffle pull duffle/example:0.1.0
 `
-
+	var insecure bool
 	cmd := &cobra.Command{
 		Use:   "pull",
 		Short: "pull a CNAB bundle from a repository",
 		Long:  usage,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path, err := getBundleFile(args[0])
+			home := home.Home(homePath())
+			url, err := getBundleRepoURL(args[0], home)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(w, path)
+			b, err := loadBundle(url.String(), insecure)
+			bundleFilepath := filepath.Join(home.Cache(), fmt.Sprintf("%s-%s.json", strings.Replace(b.Name, "/", "-", -1), b.Version))
+			if err := b.WriteFile(bundleFilepath, 0644); err != nil {
+				return err
+			}
+			fmt.Fprintln(w, bundleFilepath)
 			return nil
 		},
 	}
+	cmd.Flags().BoolVarP(&insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
 
 	return cmd
 }

--- a/cmd/duffle/uninstall.go
+++ b/cmd/duffle/uninstall.go
@@ -4,9 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	"github.com/deis/duffle/pkg/action"
+	"github.com/spf13/cobra"
 )
 
 const usage = `Uninstalls an installation of a CNAB bundle.
@@ -44,7 +43,7 @@ func newUninstallCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uc.name = args[0]
 			uc.Out = cmd.OutOrStdout()
-			bundleFile, err := bundleFileOrArg2(args, bundleFile, uc.Out)
+			bundleFile, err := bundleFileOrArg2(args, bundleFile, uc.Out, uc.insecure)
 			// If no bundle was found, we just wait for the claim system
 			// to load its bundleFile
 			if err == nil {

--- a/cmd/duffle/upgrade.go
+++ b/cmd/duffle/upgrade.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/deis/duffle/pkg/action"
-
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +53,7 @@ func newUpgradeCmd() *cobra.Command {
 			}
 			uc.name = args[0]
 			uc.Out = cmd.OutOrStdout()
-			bundleFile, err := optBundleFileOrArg2(args, bundleFile, uc.Out)
+			bundleFile, err := optBundleFileOrArg2(args, bundleFile, uc.Out, uc.insecure)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously, if a bundle was pushed in a PGP enveloppe, pulling or
installing it would fail because the incorrect loader was used.
This fix that