### PR TITLE
fix: add signing support to pulls

### DIFF
--- a/cmd/duffle/credential_generate.go
+++ b/cmd/duffle/credential_generate.go
@@ -45,7 +45,7 @@ func newCredentialGenerateCmd(out io.Writer) *cobra.Command {
 		Short:   "generate a credentialset from a bundle",
 		Long:    credentialGenerateHelp,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			bf, err := getBundleFileFromCredentialsArg(args, bundleFile, out)
+			bf, err := getBundleFileFromCredentialsArg(args, bundleFile, out, insecure)
 			if err != nil {
 				return err
 			}
@@ -165,7 +165,7 @@ func genCredentialSurvey(name string) (credentials.CredentialStrategy, error) {
 	return c, nil
 }
 
-func getBundleFileFromCredentialsArg(args []string, bundleFile string, w io.Writer) (string, error) {
+func getBundleFileFromCredentialsArg(args []string, bundleFile string, w io.Writer, insecure bool) (string, error) {
 	switch {
 	case len(args) < 1:
 		return "", errors.New("This command requires at least one argument: NAME (name for the credentialset). It also requires a BUNDLE (CNAB bundle name) or file (using -f)\nValid inputs:\n\t$ duffle credentials generate NAME BUNDLE\n\t$ duffle credentials generate NAME -f path-to-bundle.json")
@@ -174,7 +174,7 @@ func getBundleFileFromCredentialsArg(args []string, bundleFile string, w io.Writ
 	case len(args) < 2 && bundleFile == "":
 		return "", errors.New("required arguments are NAME (name for the credentialset) and BUNDLE (CNAB bundle name) or file")
 	case len(args) == 2:
-		return getBundleFile(args[1])
+		return getBundleFile(args[1], insecure)
 	}
 	return bundleFile, nil
 }

--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -71,7 +71,7 @@ For unpublished CNAB bundles, you can also load the bundle.json directly:
 		Short: "install a CNAB bundle",
 		Long:  usage,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			bundleFile, err := bundleFileOrArg2(args, bundleFile, cmd.OutOrStdout())
+			bundleFile, err := bundleFileOrArg2(args, bundleFile, cmd.OutOrStdout(), insecure)
 			if err != nil {
 				return err
 			}
@@ -137,7 +137,7 @@ For unpublished CNAB bundles, you can also load the bundle.json directly:
 	return cmd
 }
 
-func bundleFileOrArg2(args []string, bundleFile string, w io.Writer) (string, error) {
+func bundleFileOrArg2(args []string, bundleFile string, w io.Writer, insecure bool) (string, error) {
 	switch {
 	case len(args) < 1:
 		return "", errors.New("This command requires at least one argument: NAME (name for the installation). It also requires a BUNDLE (CNAB bundle name) or file (using -f)\nValid inputs:\n\t$ duffle install NAME BUNDLE\n\t$ duffle install NAME -f path-to-bundle.json")
@@ -146,14 +146,14 @@ func bundleFileOrArg2(args []string, bundleFile string, w io.Writer) (string, er
 	case len(args) < 2 && bundleFile == "":
 		return "", errors.New("required arguments are NAME (name of the installation) and BUNDLE (CNAB bundle name) or file")
 	case len(args) == 2:
-		return getBundleFile(args[1])
+		return getBundleFile(args[1], insecure)
 	}
 	return bundleFile, nil
 }
 
 // optBundleFileOrArg2 optionally gets a bundle file.
 // Returning an empty string with no error is a possible outcome.
-func optBundleFileOrArg2(args []string, bundleFile string, w io.Writer) (string, error) {
+func optBundleFileOrArg2(args []string, bundleFile string, w io.Writer, insecure bool) (string, error) {
 	switch {
 	case len(args) < 1:
 		// No bundle provided
@@ -165,7 +165,7 @@ func optBundleFileOrArg2(args []string, bundleFile string, w io.Writer) (string,
 		return "", nil
 	case len(args) == 2:
 		var err error
-		bundleFile, err = getBundleFile(args[1])
+		bundleFile, err = getBundleFile(args[1], insecure)
 		if err != nil {
 			return "", err
 		}
@@ -267,7 +267,7 @@ func getBundleRepoURL(bundleName string, home home.Home) (*url.URL, error) {
 	return url, nil
 }
 
-func getBundleFile(bundleName string) (string, error) {
+func getBundleFile(bundleName string, insecure bool) (string, error) {
 	home := home.Home(homePath())
 	url, err := getBundleRepoURL(bundleName, home)
 	if err != nil {
@@ -283,11 +283,28 @@ func getBundleFile(bundleName string) (string, error) {
 		return "", fmt.Errorf("request to %s responded with a non-200 status code: %d", url, resp.StatusCode)
 	}
 
-	bundle, err := bundle.ParseReader(resp.Body)
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("could not read bundle from remote server: %s", err)
+	}
+
+	ldr, err := getLoader(insecure)
 	if err != nil {
 		return "", err
 	}
-	bundleFilepath := filepath.Join(home.Cache(), fmt.Sprintf("%s-%s.json", strings.Replace(bundle.Name, "/", "-", -1), bundle.Version))
+
+	bundle, err := ldr.LoadData(data)
+	if err != nil {
+		return "", err
+	}
+
+	ext := "cnab"
+	if insecure {
+		ext = "json"
+	}
+
+	bundleFilepath := filepath.Join(home.Cache(), fmt.Sprintf("%s-%s.%s", strings.Replace(bundle.Name, "/", "-", -1), bundle.Version, ext))
+	//bundleFilepath := filepath.Join(home.Cache(), fmt.Sprintf("%s-%s.json", strings.Replace(bundle.Name, "/", "-", -1), bundle.Version))
 	if err := bundle.WriteFile(bundleFilepath, 0644); err != nil {
 		return "", err
 	}
@@ -295,16 +312,24 @@ func getBundleFile(bundleName string) (string, error) {
 	return bundleFilepath, nil
 }
 
-func loadBundle(bundleFile string, insecure bool) (*bundle.Bundle, error) {
-	var l loader.Loader
+func getLoader(insecure bool) (loader.Loader, error) {
+	var load loader.Loader
 	if insecure {
-		l = loader.NewUnsignedLoader()
+		load = loader.NewUnsignedLoader()
 	} else {
 		kr, err := loadVerifyingKeyRings(homePath())
 		if err != nil {
 			return nil, err
 		}
-		l = loader.NewSecureLoader(kr)
+		load = loader.NewSecureLoader(kr)
+	}
+	return load, nil
+}
+
+func loadBundle(bundleFile string, insecure bool) (*bundle.Bundle, error) {
+	l, err := getLoader(insecure)
+	if err != nil {
+		return nil, err
 	}
 	return l.Load(bundleFile)
 }

--- a/cmd/duffle/install_test.go
+++ b/cmd/duffle/install_test.go
@@ -41,7 +41,7 @@ func TestGetBundleFile(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			filePath, err := getBundleFile(tc.File)
+			filePath, err := getBundleFile(tc.File, true)
 			if err != nil {
 				t.Error(err)
 			}

--- a/cmd/duffle/pull.go
+++ b/cmd/duffle/pull.go
@@ -14,12 +14,13 @@ Example:
 	$ duffle pull duffle/example:0.1.0
 `
 
+	var insecure bool
 	cmd := &cobra.Command{
 		Use:   "pull",
 		Short: "pull a CNAB bundle from a repository",
 		Long:  usage,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path, err := getBundleFile(args[0])
+			path, err := getBundleFile(args[0], insecure)
 			if err != nil {
 				return err
 			}
@@ -27,6 +28,8 @@ Example:
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
 
 	return cmd
 }

--- a/cmd/duffle/uninstall.go
+++ b/cmd/duffle/uninstall.go
@@ -44,7 +44,7 @@ func newUninstallCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uc.name = args[0]
 			uc.Out = cmd.OutOrStdout()
-			bundleFile, err := bundleFileOrArg2(args, bundleFile, uc.Out)
+			bundleFile, err := bundleFileOrArg2(args, bundleFile, uc.Out, uc.insecure)
 			// If no bundle was found, we just wait for the claim system
 			// to load its bundleFile
 			if err == nil {

--- a/cmd/duffle/upgrade.go
+++ b/cmd/duffle/upgrade.go
@@ -54,7 +54,7 @@ func newUpgradeCmd() *cobra.Command {
 			}
 			uc.name = args[0]
 			uc.Out = cmd.OutOrStdout()
-			bundleFile, err := optBundleFileOrArg2(args, bundleFile, uc.Out)
+			bundleFile, err := optBundleFileOrArg2(args, bundleFile, uc.Out, uc.insecure)
 			if err != nil {
 				return err
 			}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -7,7 +7,10 @@ import (
 
 // Loader provides an interface for loading a bundle
 type Loader interface {
+	// Load a bundle from a local file
 	Load(source string) (*bundle.Bundle, error)
+	// Load a bundle from raw data
+	LoadData(data []byte) (*bundle.Bundle, error)
 }
 
 // New creates a loader for signed bundle files.

--- a/pkg/loader/secure_loader.go
+++ b/pkg/loader/secure_loader.go
@@ -28,7 +28,15 @@ func (s *SecureLoader) Load(filename string) (*bundle.Bundle, error) {
 	if err != nil {
 		return b, err
 	}
+	return s.LoadData(data)
+}
+
+// LoadData loads a bundle from data.
+//
+// This will perform verification of tbe bundle, extract the JSON, and then
+// parse the JSON into a *Bundle.
+func (s *SecureLoader) LoadData(data []byte) (*bundle.Bundle, error) {
 	verifier := signature.NewVerifier(s.keyring)
-	b, _, err = verifier.Extract(data)
+	b, _, err := verifier.Extract(data)
 	return b, err
 }

--- a/pkg/loader/unsigned_loader.go
+++ b/pkg/loader/unsigned_loader.go
@@ -27,6 +27,13 @@ func (l *UnsignedLoader) Load(filename string) (*bundle.Bundle, error) {
 	if err != nil {
 		return b, err
 	}
+	return l.LoadData(data)
+}
+
+// LoadData loads a Bundle from the given data.
+//
+// This loads an unsigned JSON bundle file into a *Bundle.
+func (l *UnsignedLoader) LoadData(data []byte) (*bundle.Bundle, error) {
 	return bundle.Unmarshal(data)
 }
 


### PR DESCRIPTION
This adds support for verifying bundles when they are pulled from a remote repo.

Closes #357