### PR TITLE
Fix wrong help text message for key sign

### DIFF
--- a/cmd/duffle/key_sign.go
+++ b/cmd/duffle/key_sign.go
@@ -16,7 +16,7 @@ import (
 const keySignDesc = `Clear-sign a given bundle.json file.
 
 This remarshals the bundle.json into canonical form, and then clear-signs the JSON.
-The output is written to STDOUT.
+By default, the signed bundle is written in a bundle.cnab file in the current directory.
 
 If no key name is supplied, this uses the first signing key in the secret keyring.
 `


### PR DESCRIPTION
This PR updates the help message for `duffle key sign` - specifically, regarding the output of the signed bundle.

closes #367