### PR TITLE
Fix: Manifest loader respects json tags

### DIFF
--- a/pkg/duffle/manifest/load.go
+++ b/pkg/duffle/manifest/load.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/deis/duffle/pkg/duffle"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 )
 
@@ -17,12 +18,15 @@ func Load(name, dir string) (*Manifest, error) {
 		v.SetConfigFile(filepath.Join(dir, name))
 	}
 	v.AddConfigPath(dir)
+
 	err := v.ReadInConfig()
 	if err != nil {
 		return nil, err
 	}
 
 	m := New()
-	v.Unmarshal(m)
+	v.Unmarshal(m, func(cfg *mapstructure.DecoderConfig) {
+		cfg.TagName = "json"
+	})
 	return m, nil
 }

--- a/pkg/duffle/manifest/manifest_test.go
+++ b/pkg/duffle/manifest/manifest_test.go
@@ -50,6 +50,18 @@ func TestLoad(t *testing.T) {
 			if _, ok := m.Components["cnab"]; !ok {
 				t.Errorf("expected a component named cnab but got %v", m.Components)
 			}
+
+			if len(m.Parameters) != 1 {
+				t.Fatalf("expected 1 parameter but got %d", len(m.Parameters))
+			}
+
+			if _, ok := m.Parameters["foo"]; !ok {
+				t.Fatalf("expected a parameter named foo but got %v", m.Parameters)
+			}
+
+			if m.Parameters["foo"].DataType != "string" {
+				t.Errorf("expected parameter foo to have data type string, but got %q", m.Parameters["foo"].DataType)
+			}
 		})
 	}
 }

--- a/pkg/duffle/manifest/testdata/duffle.json
+++ b/pkg/duffle/manifest/testdata/duffle.json
@@ -8,5 +8,10 @@
         "registry": "microsoft"
       }
     }
+  },
+  "parameters": {
+    "foo":{
+      "type": "string"
+    }
   }
 }

--- a/pkg/duffle/manifest/testdata/duffle.toml
+++ b/pkg/duffle/manifest/testdata/duffle.toml
@@ -4,3 +4,6 @@ name = "testbundle"
         name = "cnab"
         builder = "docker"
         configuration = { registry = "microsoft" }
+[parameters]
+    [parameters.foo]
+        type = "string"

--- a/pkg/duffle/manifest/testdata/duffle.yaml
+++ b/pkg/duffle/manifest/testdata/duffle.yaml
@@ -5,3 +5,6 @@ components:
     builder: docker
     configuration:
       registry: microsoft
+parameters:
+  foo:
+      type: string


### PR DESCRIPTION
The manifest stucture contains structures tagged with json fields.
However, the viper reader by default only respect mapstructure tags.
This made some fields missing when building a manifest into a bundle
(e.g: the parameters DataType which is json-tagged as `type` failed to
parse).

This fix that by instructing mapstructure to respect json tags.