### PR TITLE
Add --file/-f flag for duffle key add/sign/verify

### DIFF
--- a/cmd/duffle/key_sign.go
+++ b/cmd/duffle/key_sign.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -24,22 +25,23 @@ If no key name is supplied, this uses the first signing key in the secret keyrin
 func newKeySignCmd(w io.Writer) *cobra.Command {
 	var (
 		identity   string
+		bundleFile string
 		outfile    string
 		noValidate bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "sign FILE",
+		Use:   "sign",
 		Short: "clear-sign a bundle.json file",
 		Long:  keySignDesc,
-		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			h := home.Home(homePath())
 			secring := h.SecretKeyRing()
-			return signFile(args[0], secring, identity, outfile, noValidate)
+			return signFile(bundleFile, secring, identity, outfile, noValidate)
 		},
 	}
 	cmd.Flags().StringVarP(&identity, "user", "u", "", "the user ID of the key to use. Format is either email address or 'NAME (COMMENT) <EMAIL>'")
+	cmd.Flags().StringVarP(&bundleFile, "file", "f", "", "path to bundle file to sign")
 	cmd.Flags().StringVarP(&outfile, "output-file", "o", "bundle.cnab", "the name of the output file")
 	cmd.Flags().BoolVar(&noValidate, "no-validate", false, "do not validate the JSON before marshaling it.")
 
@@ -49,7 +51,7 @@ func newKeySignCmd(w io.Writer) *cobra.Command {
 func signFile(filepath, keyring, identity, outfile string, skipValidation bool) error {
 	// Verify that file exists
 	if fi, err := os.Stat(filepath); err != nil {
-		return err
+		return fmt.Errorf("cannot find bundle file to sign: %v", err)
 	} else if fi.IsDir() {
 		return errors.New("cannot sign a directory")
 	}

--- a/cmd/duffle/key_verify.go
+++ b/cmd/duffle/key_verify.go
@@ -19,25 +19,32 @@ keyring(s) that can successfully decrypt the signature and verify the hash.
 `
 
 func newKeyVerifyCmd(w io.Writer) *cobra.Command {
-	var public bool
+	var (
+		public     bool
+		bundleFile string
+	)
+
 	cmd := &cobra.Command{
-		Use:   "verify FILE",
+		Use:   "verify",
 		Short: "verify the signature on a signed bundle",
 		Long:  keyVerifyDesc,
-		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			h := home.Home(homePath())
 			secret := h.SecretKeyRing()
 			public := h.PublicKeyRing()
-			return verifySig(args[0], public, secret, w)
+			return verifySig(bundleFile, public, secret, w)
 		},
 	}
 	cmd.Flags().BoolVarP(&public, "public", "p", false, "show public key IDs instead of private key IDs")
+	cmd.Flags().StringVarP(&bundleFile, "file", "f", "", "path to signed bundle to verify")
 
 	return cmd
 }
 
 func verifySig(filename, public, private string, out io.Writer) error {
+	if filename == "" {
+		return fmt.Errorf("no bundle provided to verify")
+	}
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
As per the comment in #346 - should the default file for `sign` be `bundle.json` in the current directory?
It is somehow inconsistent with the other commands in this command set - but if we think it would be helpful, we can easily add it in this PR.

closes #346 