### PR TITLE
ref: print credentials only on dry-run

### DIFF
--- a/cmd/duffle/credential_generate.go
+++ b/cmd/duffle/credential_generate.go
@@ -70,8 +70,8 @@ func newCredentialGenerateCmd(out io.Writer) *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("%v", string(data))
 			if dryRun {
+				fmt.Fprintf(out, "%v", string(data))
 				return nil
 			}
 


### PR DESCRIPTION
This fixes the 'duffle creds gen' command to not print credentials by default.

In noticed this while looking at #370, though it does not fix all of that issue.