### PR TITLE
feat(brigade.js): add GH Checks support

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -31,28 +31,98 @@ function build(e, project) {
     "make test"
   ];
 
-  start = ghNotify("pending", `Build started as ${ e.buildID }`, e, project)
+  return build
+}
 
-  // Run tests in parallel. Then if it's a release, push binaries.
-  // Then send GitHub a notification on the status.
-  Group.runAll([start, build])
-    .then(() => {
-        return ghNotify("success", `Build ${ e.buildID } passed`, e, project).run()
-    })
-    .then(() => {
-      var runRelease = false
-      if (e.type == "push" && e.revision.ref.startsWith("refs/tags/")) {
-        // Run the release in the background.
-        runRelease = true
-        let parts = e.revision.ref.split("/", 3)
-        let tag = parts[2]
-        return release(project, tag)
+// Here we can add additional Check Runs, which will run in parallel and
+// report their results independently to GitHub
+function runSuite(e, p) {
+  // For now, this is the one-stop shop running build, lint and test targets
+  runTests(e, p).catch(e => {console.error(e.toString())});
+}
+
+// runTests is a Check Run that is ran as part of a Checks Suite
+function runTests(e, p) {
+  console.log("Check requested")
+
+    // Create Notification object (which is just a Job to update GH using the Checks API)
+    var note = new Notification(`tests`, e, p);
+    note.conclusion = "";
+    note.title = "Run Tests";
+    note.summary = "Running the test targets for " + e.revision.commit;
+    note.text = "This test will ensure build, linting and tests all pass."
+
+    // Send notification, then run, then send pass/fail notification
+    return notificationWrap(build(e, p), note)
+}
+
+// A GitHub Check Suite notification
+class Notification {
+  constructor(name, e, p) {
+      this.proj = p;
+      this.payload = e.payload;
+      this.name = name;
+      this.externalID = e.buildID;
+      // TODO: add Kashti link when available
+      // this.detailsURL = `https://<kashti domain>/kashti/builds/${ e.buildID }`;
+      this.title = "running check";
+      this.text = "";
+      this.summary = "";
+
+      // count allows us to send the notification multiple times, with a distinct pod name
+      // each time.
+      this.count = 0;
+
+      // One of: "success", "failure", "neutral", "cancelled", or "timed_out".
+      this.conclusion = "neutral";
+  }
+
+  // Send a new notification, and return a Promise<result>.
+  run() {
+      this.count++
+      var j = new Job(`${ this.name }-${ this.count }`, "technosophos/brigade-github-check-run:latest");
+      j.env = {
+          CHECK_CONCLUSION: this.conclusion,
+          CHECK_NAME: this.name,
+          CHECK_TITLE: this.title,
+          CHECK_PAYLOAD: this.payload,
+          CHECK_SUMMARY: this.summary,
+          CHECK_TEXT: this.text,
+          // TODO: add when applicable
+          // CHECK_DETAILS_URL: this.detailsURL,
+          CHECK_EXTERNAL_ID: this.externalID
       }
-      return Promise.resolve(runRelease)
-    })
-    .catch(err => {
-      return ghNotify("failure", `failed build ${ e.buildID }`, e, project).run()
-    });
+      return j.run();
+  }
+}
+
+// Helper to wrap a job execution between two notifications.
+async function notificationWrap(job, note, conclusion) {
+  if (conclusion == null) {
+      conclusion = "success"
+  }
+  await note.run();
+  try {
+      let res = await job.run()
+      const logs = await job.logs();
+
+      note.conclusion = conclusion;
+      note.summary = `Task "${ job.name }" passed`;
+      note.text = note.text = "```" + res.toString() + "```\nTest Complete";
+      return await note.run();
+  } catch (e) {
+      const logs = await job.logs();
+      note.conclusion = "failure";
+      note.summary = `Task "${ job.name }" failed for ${ e.buildID }`;
+      note.text = "```" + logs + "```\nFailed with error: " + e.toString();
+      try {
+          return await note.run();
+      } catch (e2) {
+          console.error("failed to send notification: " + e2.toString());
+          console.error("original error: " + e.toString());
+          return e2;
+      }
+  }
 }
 
 function release(project, tag) {
@@ -100,26 +170,6 @@ function release(project, tag) {
   ])
 }
 
-function ghNotify(state, msg, e, project) {
-  if (e.revision.commit) {
-    const gh = new Job(`${projectName}-notify-${state}`, "technosophos/github-notify:latest")
-
-    gh.env = {
-      GH_REPO: project.repo.name,
-      GH_STATE: state,
-      GH_DESCRIPTION: msg,
-      GH_CONTEXT: projectName,
-      GH_TOKEN: project.secrets.ghToken,
-      GH_COMMIT: e.revision.commit
-    }
-
-    return gh
-  } else {
-    console.log(`Warning: GitHub notification not sent for state '${state}' as no commit was found.`)
-    return noop
-  }
-}
-
 function slackNotify(title, msg, project) {
   if (project.secrets.SLACK_WEBHOOK) {
     var slack = new Job(`${projectName}-slack-notify`, "technosophos/slack-notify:latest")
@@ -140,9 +190,13 @@ function slackNotify(title, msg, project) {
   }
 }
  
-events.on("exec", build)
-events.on("push", build)
-events.on("pull_request", build)
+events.on("exec", (e, p) => {
+  return build(e, p).run()
+})
+
+events.on("check_suite:requested", runSuite)
+events.on("check_suite:rerequested", runSuite)
+events.on("check_run:rerequested", runSuite)
 
 events.on("release", (e, p) => {
   /*


### PR DESCRIPTION
Switches from 'classic' commit status updating to using the Checks API.  

Thanks to @technosophos for example pattern used in https://github.com/technosophos/zolver.

Closes https://github.com/deis/duffle/issues/327 and https://github.com/deis/duffle/issues/328