### PR TITLE
remove script lines in azure pipelines yaml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,10 +26,6 @@ steps:
 - script: |
     go version
     go get -v -t -d ./...
-    if [ -f Gopkg.toml ]; then
-        curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-        dep ensure
-    fi
     make bootstrap build test lint
   workingDirectory: '$(modulePath)'
   displayName: 'Get dependencies, build, test'


### PR DESCRIPTION
Removing the block that checks for Gopkg.toml existence, since make bootstrap does the same thing