### PR TITLE
feat: load signed bundles with --insecure

### DIFF
--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -51,7 +51,23 @@ Windows Example:
 
 For unpublished CNAB bundles, you can also load the bundle.json directly:
 
-    $ duffle install dev_bundle -f path/to/bundle.json
+	$ duffle install dev_bundle -f path/to/bundle.json
+	
+
+Verifying and --insecure:
+
+  When the --insecure flag is passed, verification steps will not be performed. This means
+  that Duffle will accept both unsigned (bundle.json) and signed (bundle.cnab) files, but
+  will not perform any validation. The following table illustrates this:
+
+	Bundle     Key known?    Flag            Result
+	------     ----------    -----------     ------
+	Signed     Known         None            Okay
+	Signed     Known         --insecure      Okay
+	Signed     Unknown       None            Verification error
+	Signed     Unknown       --insecure      Okay
+	Unsigned   N/A           None            Verification error
+	Unsigned   N/A           --insecure      Okay
 `
 	var (
 		installDriver    string
@@ -321,7 +337,7 @@ func getBundleFile(bundleName string, insecure bool) (string, error) {
 func getLoader(insecure bool) (loader.Loader, error) {
 	var load loader.Loader
 	if insecure {
-		load = loader.NewUnsignedLoader()
+		load = loader.NewDetectingLoader()
 	} else {
 		kr, err := loadVerifyingKeyRings(homePath())
 		if err != nil {

--- a/pkg/loader/detecting_loader.go
+++ b/pkg/loader/detecting_loader.go
@@ -1,0 +1,46 @@
+package loader
+
+import (
+	"github.com/deis/duffle/pkg/bundle"
+
+	"golang.org/x/crypto/openpgp/clearsign"
+)
+
+// DetectingLoader loads a file or data, and then determines the content.
+//
+// A DetectingLoader NEVER verifies a signature. If the bundle is signed, it will extract
+// the body, and then parse. If it is raw JSON, it will parse.
+//
+// DetectingLoader is INSECURE, as it does not verify the bundle.
+type DetectingLoader struct{}
+
+// NewDetectingLoader creates a new loader that can detect the file type
+//
+// It will only detect between the '.cnab' format (signed bundles) and
+// the '.json' (JSON) format.
+func NewDetectingLoader() *DetectingLoader {
+	return &DetectingLoader{}
+}
+
+// Load loads a file from the filesystem and parses it.
+func (l *DetectingLoader) Load(filename string) (*bundle.Bundle, error) {
+	data, err := loadData(filename)
+	if err != nil {
+		return nil, err
+	}
+	return l.LoadData(data)
+}
+
+// LoadData loads file from a byte slice and parses it.
+func (l *DetectingLoader) LoadData(data []byte) (*bundle.Bundle, error) {
+	// clearsign.Decode provides a safe way of dealing with clearsigned
+	// blocks. It will return a block ONLY IF it finds a clearsign header
+	// at the beginning of a line, which is not valid JSON (and therefore)
+	// can't occur in a legitimate bundle.json).
+	block, _ := clearsign.Decode(data)
+	if block != nil {
+		data = block.Bytes
+	}
+	// Delegate parsing to an unsigned_loader
+	return NewUnsignedLoader().LoadData(data)
+}

--- a/pkg/loader/detecting_loader_test.go
+++ b/pkg/loader/detecting_loader_test.go
@@ -1,0 +1,27 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectingLoader_Signed(t *testing.T) {
+	is := assert.New(t)
+
+	b, err := NewDetectingLoader().Load(testSigned)
+	is.NoError(err)
+	is.Equal(b.Name, "example_bundle")
+}
+
+func TestDetectingLoader_Unsigned(t *testing.T) {
+	is := assert.New(t)
+
+	bundle, err := NewDetectingLoader().Load(testFooJSON)
+	if err != nil {
+		t.Fatalf("cannot load bundle: %v", err)
+	}
+
+	is.Equal("foo", bundle.Name)
+	is.Equal("1.0", bundle.Version)
+}


### PR DESCRIPTION
Previously, `--insecure` only worked with bundle.json files. Now it works with bundle.cnab files as well.

And thanks to @itowlson for the pretty table.