### PR TITLE
fix: `duffle inspect` cannot display bundles not in non-remote stores

### DIFF
--- a/cmd/duffle/inspect.go
+++ b/cmd/duffle/inspect.go
@@ -1,42 +1,40 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
-
-	"github.com/deis/duffle/pkg/duffle/home"
-	"github.com/deis/duffle/pkg/repo"
 )
 
 func newInspectCmd(w io.Writer) *cobra.Command {
+	var (
+		insecure bool
+	)
+
+	const usage = ` Returns information about an application bundle.
+
+	Example:
+		$ duffle inspect duffle/example:0.1.0
+
+	To inspect unsigned bundles, pass the --insecure flag:
+		$ duffle inspect duffle/unsinged-example:0.1.0 --insecure
+`
+
 	cmd := &cobra.Command{
-		Use:   "inspect",
+		Use:   "inspect NAME",
 		Short: "return low-level information on application bundles",
+		Long:  usage,
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home := home.Home(homePath())
 			bundleName := args[0]
 
-			ref, err := getReference(bundleName)
-			if err != nil {
-				return fmt.Errorf("could not parse reference for %s: %v", bundleName, err)
-			}
-
-			// read the bundle reference from repositories.json
-			index, err := repo.LoadIndex(home.Repositories())
-			if err != nil {
-				return fmt.Errorf("cannot open %s: %v", home.Repositories(), err)
-			}
-
-			digest, err := index.Get(ref.Name(), ref.Tag())
+			bundle, err := loadOrPullBundle(bundleName, insecure)
 			if err != nil {
 				return err
 			}
 
-			f, err := os.Open(filepath.Join(home.Bundles(), digest))
+			f, err := os.Open(bundle)
 			if err != nil {
 				return err
 			}
@@ -47,6 +45,9 @@ func newInspectCmd(w io.Writer) *cobra.Command {
 			return nil
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
 
 	return cmd
 }


### PR DESCRIPTION
Below is a sample of how this works:

```
radu:duffle $ duffle bundles
NAME    VERSION DIGEST
radu:duffle $ duffle inspect helloworld:0.1.1
Error: no signature block in data
radu:duffle $ duffle inspect helloworld:0.1.1 --insecure
{
    "name": "helloworld",
    "version": "0.1.1",
    "description": "",
    "invocationImages": [
        {
            "imageType": "docker",
            "image": "cnab/helloworld:0.1.1"
        }
    ],
    "images": [],
    "parameters": {
        "port": {
            "type": "int",
            "defaultValue": 8080,
            "required": false,
            "metadata": {},
            "destination": null
        }
    },
    "credentials": null
}
radu:duffle $duffle bundles
NAME                            VERSION DIGEST
hub.cnlabs.io/helloworld        0.1.1   f3601d436c77c4c5c074e57edc84d095a4d52b76
```

cc @itowlson 

Depends on #384 

closes #335