### PR TITLE
Add dep check to the CI cycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ debug:
 test:
 	go test $(TESTFLAGS) ./...
 
+.PHONY: dep-validate
+dep-validate:
+	dep check
+
 .PHONY: lint
 lint:
 	golangci-lint run --config ./golangci.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,6 @@ steps:
 - script: |
     go version
     go get -v -t -d ./...
-    make bootstrap build test lint
+    make bootstrap dep-validate build test lint
   workingDirectory: '$(modulePath)'
   displayName: 'Get dependencies, build, test'

--- a/brigade.js
+++ b/brigade.js
@@ -27,6 +27,7 @@ function build(e, project) {
     `cp -a /src/.git ${localPath}`,
     `cd ${localPath}`,
     "make bootstrap",
+    "make dep-validate",
     "make lint",
     "make test"
   ];


### PR DESCRIPTION
`dep check` validates if the input-imports, Gopkg.lock and Gopkg.toml are in sync. If they are not in sync, dep check throws an error.

In the case of duffle, `dep check` will help detect cases when new input-imports are added to the code base and Gopkg.lock is not updated. This will ensure that deps are always consistent across all clones of the repo