### PR TITLE
fix: remove references to other commands from error messages

### DIFF
--- a/cmd/duffle/credential_add.go
+++ b/cmd/duffle/credential_add.go
@@ -96,7 +96,7 @@ func addCredentialSet(dest, path string) error {
 
 	// check if it already exists
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
-		return fmt.Errorf("Credential set (%s) already exists. Run `$ duffle creds remove %s` and try again", cs.Name, cs.Name)
+		return fmt.Errorf("Credential set (%s) already exists", cs.Name)
 	}
 
 	if err := copyCredentialSetFile(dest, path); err != nil {

--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -96,7 +96,7 @@ Verifying and --insecure:
 			// look in claims store for another claim with the same name
 			_, err = claimStorage().Read(installationName)
 			if err != claim.ErrClaimNotFound {
-				return fmt.Errorf("a claim with the name %v already exists. Execute `$ duffle claims show %v` to inspect it", installationName, installationName)
+				return fmt.Errorf("a claim with the name %v already exists", installationName)
 			}
 
 			bun, err = loadBundle(bundleFile, insecure)


### PR DESCRIPTION
Fix errors that were confusing when they appeared inside of the VS Code extension.

Closes #399