### PR TITLE
fix: Use detecting loader for --insecure

### DIFF
--- a/cmd/duffle/pull.go
+++ b/cmd/duffle/pull.go
@@ -98,7 +98,7 @@ func pullBundle(bundleName string, insecure bool) (string, error) {
 func getLoader(insecure bool) (loader.Loader, error) {
 	var load loader.Loader
 	if insecure {
-		load = loader.NewUnsignedLoader()
+		load = loader.NewDetectingLoader()
 	} else {
 		kr, err := loadVerifyingKeyRings(homePath())
 		if err != nil {


### PR DESCRIPTION
This adds the DetectingLoader to the `pull.go` logic, which will influence a number of other places where a bundle has to be fetched from a remote.

Closes #402