### PR TITLE
ref: normalize naming and layouts of lists

### DIFF
--- a/cmd/duffle/bundle.go
+++ b/cmd/duffle/bundle.go
@@ -12,9 +12,10 @@ Manages bundles
 
 func newBundleCmd(w io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "bundle",
-		Short: "manage bundles",
-		Long:  bundleDesc,
+		Use:     "bundle",
+		Aliases: []string{"bundles"},
+		Short:   "manage bundles",
+		Long:    bundleDesc,
 	}
 	cmd.AddCommand(
 		newBundleListCmd(w),

--- a/cmd/duffle/bundle_list.go
+++ b/cmd/duffle/bundle_list.go
@@ -56,9 +56,11 @@ func (n *NamedRepository) Digest() string {
 }
 
 func newBundleListCmd(w io.Writer) *cobra.Command {
+	var long bool
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "lists bundles pulled or built and stored locally",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "lists bundles pulled or built and stored locally",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			home := home.Home(homePath())
 			references, err := searchLocal(home)
@@ -66,15 +68,24 @@ func newBundleListCmd(w io.Writer) *cobra.Command {
 				return err
 			}
 			sort.Sort(references)
-			table := uitable.New()
-			table.AddRow("NAME", "VERSION", "DIGEST")
-			for _, ref := range references {
-				table.AddRow(ref.Name(), ref.Tag(), ref.Digest())
+			if long {
+				table := uitable.New()
+				table.AddRow("NAME", "VERSION", "DIGEST")
+				for _, ref := range references {
+					table.AddRow(ref.Name(), ref.Tag(), ref.Digest())
+				}
+				fmt.Fprintln(w, table)
+				return nil
 			}
-			fmt.Fprintln(w, table)
+
+			for _, ref := range references {
+				fmt.Println(ref.Name())
+			}
+
 			return nil
 		},
 	}
+	cmd.Flags().BoolVarP(&long, "long", "l", false, "output longer listing format")
 
 	return cmd
 }

--- a/cmd/duffle/claims_list.go
+++ b/cmd/duffle/claims_list.go
@@ -10,8 +10,9 @@ func newClaimListCmd(out io.Writer) *cobra.Command {
 	list := listCmd{out: out}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "list available claims",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "list available claims",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := &listCmd{out: out, long: list.long}
 			return l.run()

--- a/cmd/duffle/credentials.go
+++ b/cmd/duffle/credentials.go
@@ -41,7 +41,7 @@ func newCredentialsCmd(w io.Writer) *cobra.Command {
 		Use:     "credentials",
 		Short:   "manage credential sets",
 		Long:    credentialDesc,
-		Aliases: []string{"creds", "credential"},
+		Aliases: []string{"creds", "credential", "cred"},
 	}
 
 	cmd.AddCommand(

--- a/cmd/duffle/key.go
+++ b/cmd/duffle/key.go
@@ -14,7 +14,7 @@ Manages OpenPGP keys, signatures, and attestations.
 func newKeyCmd(w io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "key",
-		Aliases: []string{"signature", "sig"},
+		Aliases: []string{"keys"},
 		Short:   "manage keys",
 		Long:    keyDesc,
 	}


### PR DESCRIPTION
This fixes 'duffle bundle list' to follow the same layout conventions as the other listing commands, and also standardizes the aliases across commands.