### PR TITLE
implement `duffle login`, `duffle logout`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -48,6 +48,14 @@
   revision = "5312a61534124124185d41f09206b9fef1d88403"
 
 [[projects]]
+  digest = "1:9d013c04ff3012769abc7ea289948bf93bf82e8b22c5909f031127647609523f"
+  name = "github.com/bacongobbler/browser"
+  packages = ["."]
+  pruneopts = ""
+  revision = "792d0443b3e34e0a99a68e254084079ad9356db5"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
@@ -214,7 +222,7 @@
   version = "v0.3.3"
 
 [[projects]]
-  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   pruneopts = "NUT"
@@ -680,6 +688,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Masterminds/semver",
+    "github.com/bacongobbler/browser",
     "github.com/docker/cli/cli/command",
     "github.com/docker/cli/cli/command/image/build",
     "github.com/docker/cli/cli/config",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,10 @@
   name = "gopkg.in/yaml.v2"
   version = "2.2.1"
 
+[[constraint]]
+  name = "github.com/bacongobbler/browser"
+  version = "1.0.1"
+
 [prune]
   non-go = true
   unused-packages = true

--- a/cmd/duffle/login.go
+++ b/cmd/duffle/login.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+
+	"github.com/bacongobbler/browser"
+	"github.com/spf13/cobra"
+	"gopkg.in/AlecAivazis/survey.v1"
+
+	"github.com/deis/duffle/pkg/duffle/home"
+	"github.com/deis/duffle/pkg/repo/remote/auth"
+)
+
+type loginCmd struct {
+	out  io.Writer
+	home home.Home
+}
+
+func newLoginCmd(out io.Writer) *cobra.Command {
+	login := loginCmd{out: out}
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "log in",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			login.home = home.Home(homePath())
+			return login.run(args[0])
+		},
+	}
+
+	return cmd
+}
+
+func (l *loginCmd) run(hostname string) error {
+	url := &url.URL{
+		Scheme: "https",
+		Host:   hostname,
+		Path:   "/.auth/me",
+	}
+	fmt.Println("In order to log in, we will attempt to open a webpage in your browser which will prompt for your information. Once logged in, please enter your auth token below.")
+
+	if err := browser.Open(url.String()); err != nil {
+		fmt.Printf("Please open %s in your browser to log in.\n", url.String())
+	}
+
+	prompt := &survey.Password{
+		Message: "Please enter your auth token",
+	}
+
+	var token string
+	if err := survey.AskOne(prompt, &token, nil); err != nil {
+		return err
+	}
+
+	loginCreds, err := auth.Load(filepath.Join(l.home.String(), "auth.json"))
+	if err != nil {
+		return err
+	}
+	loginCreds.Add(url.Hostname(), auth.RepositoryCredentials{Token: token})
+	return loginCreds.WriteFile(filepath.Join(l.home.String(), "auth.json"), 0644)
+}

--- a/cmd/duffle/logout.go
+++ b/cmd/duffle/logout.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+
+	"github.com/bacongobbler/browser"
+	"github.com/spf13/cobra"
+
+	"github.com/deis/duffle/pkg/duffle/home"
+	"github.com/deis/duffle/pkg/repo/remote/auth"
+)
+
+type logoutCmd struct {
+	out  io.Writer
+	home home.Home
+}
+
+func newLogoutCmd(out io.Writer) *cobra.Command {
+	logout := logoutCmd{out: out}
+	cmd := &cobra.Command{
+		Use:   "logout",
+		Short: "log out",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logout.home = home.Home(homePath())
+			return logout.run(args[0])
+		},
+	}
+
+	return cmd
+}
+
+func (l *logoutCmd) run(hostname string) error {
+	url := &url.URL{
+		Scheme: "https",
+		Host:   hostname,
+		Path:   "/.auth/logout",
+	}
+	if err := browser.Open(url.String()); err != nil {
+		fmt.Printf("please open %s in your browser to log out.\n", url.String())
+	}
+
+	loginCreds, err := auth.Load(filepath.Join(l.home.String(), "auth.json"))
+	if err != nil {
+		return err
+	}
+	loginCreds.Remove(url.Hostname())
+	return loginCreds.WriteFile(filepath.Join(l.home.String(), "auth.json"), 0644)
+}

--- a/cmd/duffle/root.go
+++ b/cmd/duffle/root.go
@@ -46,6 +46,8 @@ func newRootCmd(outputRedirect io.Writer) *cobra.Command {
 	cmd.AddCommand(newInitCmd(outLog))
 	cmd.AddCommand(newInspectCmd(outLog))
 	cmd.AddCommand(newListCmd(outLog))
+	cmd.AddCommand(newLoginCmd(outLog))
+	cmd.AddCommand(newLogoutCmd(outLog))
 	cmd.AddCommand(newPullCmd(outLog))
 	cmd.AddCommand(newPushCmd(outLog))
 	cmd.AddCommand(newSearchCmd(outLog))

--- a/pkg/repo/remote/auth/auth.go
+++ b/pkg/repo/remote/auth/auth.go
@@ -1,0 +1,116 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
+)
+
+var (
+	// ErrNoRepoName indicates that a repository with the given name is not found.
+	ErrNoRepoName = errors.New("no repository with the given name found")
+)
+
+// RepositoryIndex defines a list of repositories with each repository's login credentials.
+type RepositoryIndex map[string]RepositoryCredentials
+
+// RepositoryCredentials defines how one authenticates against a repository.
+type RepositoryCredentials struct {
+	Token string `json:"token"`
+}
+
+// Load takes a file at the given path and returns a RepositoryIndex object
+func Load(path string) (RepositoryIndex, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return load(f)
+}
+
+// LoadReader takes a reader and returns a RepositoryIndex object
+func LoadReader(r io.Reader) (RepositoryIndex, error) {
+	return load(r)
+}
+
+// LoadBuffer reads repository metadata from a JSON byte stream
+func LoadBuffer(data []byte) (RepositoryIndex, error) {
+	return load(bytes.NewBuffer(data))
+}
+
+// Add adds a new entry to the index
+func (ri *RepositoryIndex) Add(name string, creds RepositoryCredentials) {
+	var i string
+	url, err := url.ParseRequestURI(name)
+	if err != nil {
+		i = name
+	} else {
+		i = url.Hostname()
+	}
+
+	(*ri)[i] = creds
+}
+
+// Remove removes an entry from the index
+func (ri *RepositoryIndex) Remove(name string) {
+	var i string
+	url, err := url.ParseRequestURI(name)
+	if err != nil {
+		i = name
+	} else {
+		i = url.Hostname()
+	}
+
+	delete(*ri, i)
+}
+
+// Has returns true if the index has an entry for a bundle with the given name and exact version.
+func (ri *RepositoryIndex) Has(name string) bool {
+	_, err := ri.Get(name)
+	return err == nil
+}
+
+// Get returns the digest for the given name.
+//
+// If version is empty, this will return the digest for the bundle with the highest version.
+func (ri *RepositoryIndex) Get(name string) (RepositoryCredentials, error) {
+	var i string
+	url, err := url.ParseRequestURI(name)
+	if err != nil {
+		i = name
+	} else {
+		i = url.Hostname()
+	}
+
+	rc, ok := (*ri)[i]
+	if !ok {
+		return RepositoryCredentials{}, ErrNoRepoName
+	}
+
+	return rc, nil
+}
+
+// WriteFile writes an index file to the given destination path.
+//
+// The mode on the file is set to 'mode'.
+func (ri *RepositoryIndex) WriteFile(dest string, mode os.FileMode) error {
+	b, err := json.MarshalIndent(ri, "", "    ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(dest, b, mode)
+}
+
+// load loads an index file and does minimal validity checking.
+func load(r io.Reader) (RepositoryIndex, error) {
+	i := RepositoryIndex{}
+	if err := json.NewDecoder(r).Decode(&i); err != nil && err != io.EOF {
+		return i, err
+	}
+	return i, nil
+}

--- a/pkg/repo/remote/auth/auth_test.go
+++ b/pkg/repo/remote/auth/auth_test.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAdd(t *testing.T) {
+	idx := RepositoryIndex{}
+	idx.Add("foo", RepositoryCredentials{})
+	if _, ok := idx["foo"]; !ok {
+		t.Error("expected idx['foo'] to exist")
+	}
+	fmt.Println(idx)
+
+	idx.Add("https://example.com", RepositoryCredentials{})
+	if _, ok := idx["example.com"]; !ok {
+		t.Error("expected idx['example.com'] to exist")
+	}
+
+	idx.Add("https://bar.com/foo", RepositoryCredentials{})
+	if _, ok := idx["bar.com"]; !ok {
+		t.Error("expected idx['bar.com'] to exist")
+	}
+}
+
+func TestHas(t *testing.T) {
+	idx := RepositoryIndex{
+		"foo": RepositoryCredentials{},
+	}
+
+	if !idx.Has("foo") {
+		t.Error("expected 'foo' to exist")
+	}
+}
+
+func TestGet(t *testing.T) {
+	expected := RepositoryCredentials{Token: "hi!"}
+	idx := RepositoryIndex{
+		"foo": expected,
+	}
+
+	creds, err := idx.Get("foo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if creds != expected {
+		t.Errorf("got '%s', expected '%s'", creds, expected)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	idx := RepositoryIndex{
+		"foo": RepositoryCredentials{},
+	}
+
+	idx.Remove("foo")
+
+	if idx.Has("foo") {
+		t.Error("expected 'foo' to not exist")
+	}
+}

--- a/tests/testdata/home/auth.json
+++ b/tests/testdata/home/auth.json
@@ -1,0 +1,5 @@
+{
+    "hub.cnlabs.io": {
+        "token": ""
+    }
+}


### PR DESCRIPTION
This PR implements a proof-of-concept of `duffle login` using Azure Active Directory B2C as the backing authentication mechanism for a bundle repository.

Note that this PR is *not* intended to replace the current API proposal in https://github.com/deislabs/cnab-spec/blob/master/107-repositories.md. Its only intention is to demonstrate **the experience** of `duffle login` and `duffle logout` to users while we continue to iron out the details. :)

This PR also makes a significant change in the user experience. Before searching for bundles or pushing a bundle to a registry, a user MUST run `duffle login hub.cnlabs.io` prior to interacting with it. If you don't login first, you'll be met with a nice message asking you to log in.

This was an intentional design decision; by asking the user to log into hub.cnlabs.io, we "opt out" of making hub.cnlabs.io "the default registry" for Duffle. I don't believe we planned on supporting a "Dockerhub equivalent", and this signals a clear separation between what we consider core components of duffle.

`duffle search` now searches against logged-in repositories as originally intended.

There are two ways to test this functionality:

### Ensure existing functionality still works against hub.cnlabs.io

```
><> duffle search
==> Generating a new secret keyring at /Users/bacongobbler/.duffle/secret.ring
==> Generating a new signing key with ID Matthew Fisher <bacongobbler@Matthews-MacBook-Pro.local>
==> Generating a new public keyring at /Users/bacongobbler/.duffle/public.ring
Error: You have not logged into any repository yet. Try `duffle login hub.cnlabs.io`
```

When logging in against hub.cnlabs.io, your browser will open; just ignore it and close. Enter anything into the survey field (or just press enter):

```
><> duffle login hub.cnlabs.io
In order to log in, we will attempt to open a webpage in your browser which will prompt for your information. Once logged in, please enter your auth token below.
? Please enter your auth token
```

Then verify an entry has been added to ~/.duffle/auth.json:

```
><> cat ~/.duffle/auth.json
{
    "hub.cnlabs.io": {
        "token": ""
    }
}
```

Now you should be able to `duffle search`/`duffle install` as usual.

```
><> duffle search -v
DEBU[0000] Searching https://hub.cnlabs.io/index.json...
NAME                    VERSION
aks                     0.2.0
...
```

### Testing against an Azure Active Directory B2C-backed system:

Now let's test this against a Duffle registry backed by AAD B2C.

```
><> duffle login cnlabshubtest.azurewebsites.net
In order to log in, we will attempt to open a webpage in your browser which will prompt for your information. Once logged in, please enter your auth token below.
? Please enter your auth token 
```

After calling `duffle login`, your browser will open up and prompt for a username/password. You can also create a new account. Please create an account with your username/password of choice and log in.

Please note that the Azure-y login webpage provided by Azure AD B2C [can be altered to suit BundleHub's styling](https://docs.microsoft.com/en-us/azure/active-directory-b2c/customize-ui-overview); I just haven't modified anything for demonstration purposes.

<img width="1680" alt="screen shot 2018-11-14 at 12 24 26 pm" src="https://user-images.githubusercontent.com/1360539/48479656-40d6c700-e808-11e8-8265-e8ca6369f2c0.png">

Once logged in, you should see a webpage with some raw JSON. This page displays your OAuth token the browser uses to authenticate against Azure AD B2C. Copy the token from the `id_token` field into your terminal.

<img width="1680" alt="screen shot 2018-11-14 at 12 23 06 pm" src="https://user-images.githubusercontent.com/1360539/48479590-1258ec00-e808-11e8-857d-6e219bcda96d.png">

Verify that ~/.duffle/auth.json has been created and you can `duffle pull`/`duffle install` as usual:

```
{
    "cnlabshubtest.azurewebsites.net": {
        "token": "REDACTED"
    },
    "hub.cnlabs.io": {
        "token": ""
    }
}
```

TODO:

- [x] `duffle search` should display the repository a given bundle is owned by. Prior to this PR, `duffle search` only operated against https://hub.cnlabs.io. Now it works against any registry duffle is logged into
- [x] `duffle pull` and `duffle install` should work without needing to `duffle login` first if the endpoint is unauthenticated. If a `401 Unauthorized` response is returned, then it should ask the user to log in.

On point 2, There is a technical limitation right now in Azure AD B2C where an endpoint can be authenticated OR unauthenticated, but not both. This prevents us from supporting `duffle pull hub.cnlabs.io/helloworld` without having to log in first. 😢 

Things marked as "out of scope" for this PR:

- true server-side RBAC policies. Once logged in, you can push and pull to any repository as before. This is only meant for demonstration purposes. We should probably shut off the signup page once we go live with this, but I'm leaving it in for now while others play with it. This can eventually be solved server-side given proper policies in place, but for now it's a global resource.
- saving auth tokens into a keyring store like how Docker stores credentials in the MacOS Keychain
- this bears repeating for the reviewer: because of the short time constraints we have prior to KubeCon, I do not think I'll be able to get something ready using the CNAB repository spec. This is intentionally half-baked; the only intent behind this PR is to put https://hub.cnlabs.io eventually behind a login page so the demos we have prepped for KubeCon are not wiped by malicious users.