### PR TITLE
pull version from duffle.toml

### DIFF
--- a/examples/helloworld/duffle.toml
+++ b/examples/helloworld/duffle.toml
@@ -1,4 +1,5 @@
 name = "helloworld"
+version = "0.1.0
 
 [components]
     [components.cnab]

--- a/examples/multi-component/duffle.toml
+++ b/examples/multi-component/duffle.toml
@@ -1,4 +1,5 @@
 name = "multi-component"
+version = "0.1.0"
 
 [components]
     [components.component-a]

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -69,6 +68,7 @@ func (b *Builder) PrepareBuild(bldr *Builder, mfst *manifest.Manifest, appDir st
 	}
 	bf := &bundle.Bundle{
 		Name:        ctx.Manifest.Name,
+		Version:     ctx.Manifest.Version,
 		Description: ctx.Manifest.Description,
 		Images:      []bundle.Image{},
 		Keywords:    ctx.Manifest.Keywords,
@@ -88,7 +88,6 @@ func (b *Builder) PrepareBuild(bldr *Builder, mfst *manifest.Manifest, appDir st
 					Image:     c.URI(),
 					ImageType: c.Type(),
 				}}
-			bf.Version = strings.Split(c.URI(), ":")[1]
 		} else {
 			bf.Images = append(bf.Images, bundle.Image{Name: c.Name(), URI: c.URI()})
 		}

--- a/pkg/duffle/manifest/manifest.go
+++ b/pkg/duffle/manifest/manifest.go
@@ -12,6 +12,7 @@ import (
 // Manifest represents a duffle manifest.
 type Manifest struct {
 	Name        string                                `mapstructure:"name"`
+	Version     string                                `mapstructure:"version"`
 	Description string                                `mapstructure:"description"`
 	Keywords    []string                              `mapstructure:"keywords"`
 	Maintainers []bundle.Maintainer                   `mapstructure:"maintainers"`

--- a/pkg/duffle/manifest/manifest_test.go
+++ b/pkg/duffle/manifest/manifest_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNew(t *testing.T) {
 	m := New()
-	expected := "&{manifest  [] [] map[] map[] map[]}"
+	expected := "&{manifest   [] [] map[] map[] map[]}"
 	actual := fmt.Sprintf("%v", m)
 	if expected != actual {
 		t.Errorf("wanted %s, got %s", expected, actual)


### PR DESCRIPTION
NOTE: this is a major breaking change.

Instead of inferring the bundle's version number from the invocation image SHA, users must add a `version` field to their duffle.toml files, which is then passed to the bundle.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>

closes #361 