### PR TITLE
ref(cmd/duffle): save signed bundle to local store

### DIFF
--- a/cmd/duffle/bundle_sign.go
+++ b/cmd/duffle/bundle_sign.go
@@ -131,11 +131,12 @@ func (bs *bundleSignCmd) signBundle(bundleFile, keyring string) error {
 
 	// if --output-file is provided, write and return
 	if bs.outfile != "" {
-		return ioutil.WriteFile(bs.outfile, data, 0644)
+		if err := ioutil.WriteFile(bs.outfile, data, 0644); err != nil {
+			return err
+		}
 	}
 
-	err = ioutil.WriteFile(filepath.Join(bs.home.Bundles(), digest), data, 0644)
-	if err != nil {
+	if err := ioutil.WriteFile(filepath.Join(bs.home.Bundles(), digest), data, 0644); err != nil {
 		return err
 	}
 

--- a/cmd/duffle/bundle_sign_test.go
+++ b/cmd/duffle/bundle_sign_test.go
@@ -7,9 +7,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/deis/duffle/pkg/duffle/home"
 )
 
 func TestBundleSign(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "duffle-home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(tempDir, "bundles"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
 	tmp, err := ioutil.TempFile("", "duffle-")
 	if err != nil {
 		t.Fatal(err)
@@ -24,6 +34,8 @@ func TestBundleSign(t *testing.T) {
 	cmd := bundleSignCmd{
 		outfile:  outfile,
 		identity: identity,
+		out:      ioutil.Discard,
+		home:     home.Home(tempDir),
 	}
 	if err := cmd.signBundle(bundlejson, keyring); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Currently, if an output-file is specified, a signed bundle
file will be saved to the local filesystem at the specified
path but not to the local store. This change ensures that
the bundle is saved to local store regardless of output-file.
A flag should not change the main outcome of the command; it
should enhance functionality.