### PR TITLE
fix: make inspect print JSON

### DIFF
--- a/cmd/duffle/inspect.go
+++ b/cmd/duffle/inspect.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -29,20 +28,19 @@ func newInspectCmd(w io.Writer) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bundleName := args[0]
 
-			bundle, err := loadOrPullBundle(bundleName, insecure)
+			bundleFile, err := loadOrPullBundle(bundleName, insecure)
 			if err != nil {
 				return err
 			}
 
-			f, err := os.Open(bundle)
+			bun, err := loadBundle(bundleFile, insecure)
 			if err != nil {
 				return err
 			}
-			defer f.Close()
 
-			io.Copy(w, f)
+			_, err = bun.WriteTo(w)
 
-			return nil
+			return err
 		},
 	}
 

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -33,6 +33,16 @@ func (b Bundle) WriteFile(dest string, mode os.FileMode) error {
 	return ioutil.WriteFile(dest, d, mode)
 }
 
+// WriteTo writes unsigned JSON to an io.Writer using the standard formatting.
+func (b Bundle) WriteTo(w io.Writer) (int64, error) {
+	d, err := json.MarshalIndent(b, "", "    ")
+	if err != nil {
+		return 0, err
+	}
+	l, err := w.Write(d)
+	return int64(l), err
+}
+
 // LocationRef specifies a location within the invocation package
 type LocationRef struct {
 	Path  string `json:"path" toml:"path"`


### PR DESCRIPTION
Unwrap any signed content

```
$ duffle inspect helloworld:0.1.1 --insecure
{
    "name": "helloworld",
    "version": "0.1.1",
    "description": "",
    "invocationImages": [
        {
            "imageType": "docker",
            "image": "cnab/helloworld:0.1.1"
        }
    ],
    "images": [],
    "parameters": {
        "port": {
            "type": "int",
            "defaultValue": 8080,
            "required": false,
            "metadata": {},
            "destination": null
        }
    },
    "credentials": null
}
```

Closes #336