### PR TITLE
feat: add verification to imported bundles

### DIFF
--- a/pkg/packager/import.go
+++ b/pkg/packager/import.go
@@ -24,10 +24,15 @@ type Importer struct {
 	Source      string
 	Destination string
 	Client      *client.Client
+	Loader      loader.Loader
 }
 
-// NewImporter takes a source and destination and returns an *Importer
-func NewImporter(source, destination string) (*Importer, error) {
+// NewImporter creates a new secure *Importer
+//
+// source is the filesystem path to the archive.
+// destination is the directory to unpack the contents.
+// load is a loader.Loader preconfigured for loading secure or insecure bundles.
+func NewImporter(source, destination string, load loader.Loader) (*Importer, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err
@@ -41,6 +46,7 @@ func NewImporter(source, destination string) (*Importer, error) {
 		Source:      source,
 		Destination: destination,
 		Client:      cli,
+		Loader:      load,
 	}, nil
 }
 
@@ -62,22 +68,28 @@ func (im *Importer) Import() error {
 		Compression:      archive.Gzip,
 		IncludeFiles:     []string{"."},
 		IncludeSourceDir: true,
+		// Issue #416
+		NoLchown: true,
 	}
 	if err := archive.Untar(reader, tempDir, tarOptions); err != nil {
-		return err
+		return fmt.Errorf("untar failed: %s", err)
 	}
 
-	l := loader.NewUnsignedLoader() // TODO: switch on flag
+	// We try to load a bundle.cnab file first, and fall back to a bundle.json
+	ext := "cnab"
+	if _, err := os.Stat(filepath.Join(im.Destination, "bundle.cnab")); os.IsNotExist(err) {
+		ext = "json"
+	}
 
-	bun, err := l.Load(filepath.Join(tempDir, "bundle.json"))
+	bun, err := im.Loader.Load(filepath.Join(tempDir, "bundle."+ext))
 	if err != nil {
-		return fmt.Errorf("Error loading bundle: %s", err)
+		return fmt.Errorf("failed to load bundle.%s: %s", ext, err)
 	}
 
 	bunDir := filepath.Join(im.Destination, bun.Name)
 	if _, err := os.Stat(bunDir); os.IsNotExist(err) {
 		if err := os.Rename(tempDir, bunDir); err != nil {
-			return err
+			return fmt.Errorf("move failed: %s", err)
 		}
 	} else {
 		return fmt.Errorf("Attempted to unpack bundle to %s but path already exists", bunDir)

--- a/pkg/packager/import_test.go
+++ b/pkg/packager/import_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/deis/duffle/pkg/loader"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestImport(t *testing.T) {
@@ -14,28 +17,25 @@ func TestImport(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
+	is := assert.New(t)
+
 	im := Importer{
 		Source:      "testdata/examplebun-0.1.0.tgz",
 		Destination: tempDir,
+		Loader:      loader.NewDetectingLoader(),
 	}
 
 	if err := im.Import(); err != nil {
-		t.Errorf("Expected no error, got error: %v", err)
+		t.Fatalf("import failed: %v", err)
 	}
 
 	expectedBundlePath := filepath.Join(tempDir, "examplebun")
-	fi, err := os.Stat(expectedBundlePath)
-	if err != nil {
-		t.Errorf("Expected no error examining decompressed bundle but go error %s", err)
-	} else if !fi.IsDir() {
-		t.Errorf("Expected %s to be directory but is not", expectedBundlePath)
-	}
+	is.DirExists(expectedBundlePath, "expected examplebun to exist")
 
 	im = Importer{
 		Source:      "testdata/malformed-0.1.0.tgz",
 		Destination: tempDir,
+		Loader:      loader.NewDetectingLoader(),
 	}
-	if err := im.Import(); err == nil {
-		t.Error("Expected error due to malformed bundle but got none")
-	}
+	is.Error(im.Import(), "expected malformed bundle error")
 }


### PR DESCRIPTION
This changes the default behavior of `duffle import` to attempt to verify a bundle signature. The '--insecure' flag can be specified to disable this behavior.

Closes #416