### PR TITLE
fix: fix a linting error (MASTER IS BROKEN)

### DIFF
--- a/pkg/packager/import_test.go
+++ b/pkg/packager/import_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/deis/duffle/pkg/loader"
+
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
The linter on master is failing because of this missing newline.