### PR TITLE
fix(packager): import to dir in dest not temp dir

### DIFF
--- a/pkg/packager/import_test.go
+++ b/pkg/packager/import_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deis/duffle/pkg/loader"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/deis/duffle/pkg/loader"
 )
 
 func TestImport(t *testing.T) {
@@ -30,13 +30,24 @@ func TestImport(t *testing.T) {
 		t.Fatalf("import failed: %v", err)
 	}
 
-	expectedBundlePath := filepath.Join(tempDir, "examplebun")
-	is.DirExists(expectedBundlePath, "expected examplebun to exist")
+	expectedBundlePath := filepath.Join(tempDir, "examplebun-0.1.0")
+	is.DirExistsf(expectedBundlePath, "expected examplebun to exist")
+}
 
-	im = Importer{
+func TestMalformedImport(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "duffle-import-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	im := Importer{
 		Source:      "testdata/malformed-0.1.0.tgz",
 		Destination: tempDir,
 		Loader:      loader.NewDetectingLoader(),
 	}
-	is.Error(im.Import(), "expected malformed bundle error")
+
+	if err = im.Import(); err == nil {
+		t.Error("expected malformed bundle error")
+	}
 }


### PR DESCRIPTION
Before, we were unpacking a bundle to a temp directory,
then loading it to validate the bundle. This caused
some challenges on windows around file permissions.

This PR changes the import logic so that a bundle is
unpacked in a directory at the destination specified
called <bundle-name>-<version>/ instead and then
validated. that directory is removed if the bundle
is not valid. If a directory already exists with that
name, it is overwritten.

resolves #458