### PR TITLE
ref(docs): update build docs with expected behavior

### DIFF
--- a/cmd/duffle/build.go
+++ b/cmd/duffle/build.go
@@ -31,9 +31,8 @@ import (
 )
 
 const buildDesc = `
-Builds a CNAB bundle given a path to directory that contains a duffle
-configuration file [duffle.toml, duffle.json, duffle.yaml] containing
-metadata about the bundle.
+Builds a Cloud Native Application Bundle (CNAB) given a path to directory that has a duffle
+build file [duffle.toml, duffle.json, duffle.yaml]. It builds the invocation images specified in the duffle build file and then creates or updates the bundle in local storage with the latest invocation images.
 `
 
 const (
@@ -64,7 +63,7 @@ func newBuildCmd(out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "build [path]",
-		Short: "build a CNAB bundle",
+		Short: "build a bundle and invocation images",
 		Long:  buildDesc,
 		PersistentPreRun: func(c *cobra.Command, args []string) {
 			build.dockerClientOptions.Common.SetDefaultOptions(f)

--- a/docs/proposal/203-duffle-build.md
+++ b/docs/proposal/203-duffle-build.md
@@ -1,3 +1,5 @@
 # Duffle Build
 
-This document describes how `duffle build` works, and how it uses `duffle.json`.
+This document describes how `duffle build` works, and how it uses the duffle build file: `duffle.json, duffle.yaml, duffle.toml`.
+
+`duffle build` take a path to a directory that contains a duffle build file (`duffle.json, duffle.toml, or duffle.yaml`) to build a Cloud Native Application Bundle (CNAB). In the process, it also builds all of the invocation images specified in the duffle build file.


### PR DESCRIPTION
resolves #465 

some of this doesn't actually work yet but I think updating the docs will help remind us what should happen and create less confusion and more filing of bugs if expected behavior doesn't work.