### PR TITLE
ref(*): refactor export output-file behavior

### DIFF
--- a/cmd/duffle/export.go
+++ b/cmd/duffle/export.go
@@ -13,9 +13,16 @@ import (
 )
 
 const exportDesc = `
-Packages an invocation image together with all of its associated images and generates a single gzipped tarfile
+Packages a bundle, invocation images, and all referenced images within a single
+gzipped tarfile.
 
-All images specified in the bundle metadata are saved as tar files in the artifacts/ directory along with an artifacts.json file which describes the contents of artifacts/.
+All images specified in the bundle metadata are saved as tar files in the artifacts/
+directory along with an artifacts.json file which describes the contents of artifacts/.
+
+By default, this command will use the name and version information of the bundle to create
+a compressed archive file called <name>-<version>.tgz in the current directory. This
+behavior can be augmented by specifying a file path to save the compressed bundle to using
+the --output-file flag.
 `
 
 type exportCmd struct {
@@ -45,7 +52,7 @@ func newExportCmd(w io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVarP(&export.dest, "destination", "d", "", "Save exported bundle to path")
+	f.StringVarP(&export.dest, "output-file", "o", "", "Save exported bundle to file path")
 	f.BoolVarP(&export.full, "full", "u", true, "Save bundle with all associated images")
 
 	return cmd

--- a/pkg/packager/export.go
+++ b/pkg/packager/export.go
@@ -56,7 +56,9 @@ func NewExporter(source, dest string, full bool) (*Exporter, error) {
 
 // Export prepares an artifacts directory containing all of the necessary
 //  images, packages the bundle along with the artifacts in a gzipped tar
-//  file, and saves that file to the destination
+//  file, and saves that file to the file path specified as destination.
+//  If the any part of the destination path doesn't, it will be created.
+//  exist
 func (ex *Exporter) Export() error {
 	l := loader.NewUnsignedLoader() // TODO: switch on flag
 
@@ -72,10 +74,17 @@ func (ex *Exporter) Export() error {
 	}
 
 	name := bun.Name + "-" + bun.Version
-	writer, err := os.Create(filepath.Join(ex.Destination, name+".tgz"))
-	if err != nil {
-		return err
+
+	dest := name + ".tgz"
+	if ex.Destination != "" {
+		dest = ex.Destination
 	}
+
+	writer, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("Error creating archive file: %s", err)
+	}
+
 	defer writer.Close()
 
 	tarOptions := &archive.TarOptions{

--- a/pkg/packager/export_test.go
+++ b/pkg/packager/export_test.go
@@ -14,20 +14,71 @@ func TestExport(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
+	source, err := filepath.Abs(filepath.Join("testdata", "examplebun"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ex := Exporter{
-		Source:      "testdata/examplebun",
-		Destination: tempDir,
-		Full:        false,
+		Source: source,
+		Full:   false,
+	}
+
+	tempPWD, err := ioutil.TempDir("", "duffle-export-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(pwd)
+	if err := os.Chdir(tempPWD); err != nil {
+		t.Fatal(err)
 	}
 
 	if err := ex.Export(); err != nil {
 		t.Errorf("Expected no error, got error: %v", err)
 	}
-	expectedFile := filepath.Join(tempDir, "examplebun-0.1.0.tgz")
+
+	expectedFile := "examplebun-0.1.0.tgz"
 	_, err = os.Stat(expectedFile)
 	if err != nil && os.IsNotExist(err) {
 		t.Errorf("Expected %s to exist but was not created", expectedFile)
 	} else if err != nil {
 		t.Errorf("Error with compressed bundle file: %v", err)
+	}
+}
+
+func TestExportCreatesFileProperly(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "duffle-export-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	ex := Exporter{
+		Source:      "testdata/examplebun",
+		Destination: filepath.Join(tempDir, "random-directory", "examplebun-whatev.tgz"),
+		Full:        false,
+	}
+
+	if err := ex.Export(); err == nil {
+		t.Error("Expected path does not exist error, got no error")
+	}
+
+	if err := os.MkdirAll(filepath.Join(tempDir, "random-directory"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ex.Export(); err != nil {
+		t.Errorf("Expected no error, got error: %s", err)
+	}
+
+	expectedFile := filepath.Join(tempDir, "random-directory", "examplebun-whatev.tgz")
+	_, err = os.Stat(expectedFile)
+	if err != nil && os.IsNotExist(err) {
+		t.Errorf("Expected %s to exist but was not created", expectedFile)
+	} else if err != nil {
+		t.Errorf("Error with compressed bundle archive: %v", err)
 	}
 }


### PR DESCRIPTION
+ rename destination to output-file for consistency
+ export saves to output-file if specified instead of directory
resolves #454