### PR TITLE
fix(*): fix pull image on export issue

### DIFF
--- a/cmd/duffle/export.go
+++ b/cmd/duffle/export.go
@@ -26,11 +26,12 @@ the --output-file flag.
 `
 
 type exportCmd struct {
-	dest string
-	path string
-	home home.Home
-	out  io.Writer
-	full bool
+	dest    string
+	path    string
+	home    home.Home
+	out     io.Writer
+	full    bool
+	verbose bool
 }
 
 func newExportCmd(w io.Writer) *cobra.Command {
@@ -54,6 +55,7 @@ func newExportCmd(w io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&export.dest, "output-file", "o", "", "Save exported bundle to file path")
 	f.BoolVarP(&export.full, "full", "u", true, "Save bundle with all associated images")
+	f.BoolVarP(&export.verbose, "verbose", "v", false, "Verbose output")
 
 	return cmd
 }
@@ -64,12 +66,15 @@ func (ex *exportCmd) run() error {
 		return err
 	}
 
-	exp, err := packager.NewExporter(source, ex.dest, ex.full)
+	exp, err := packager.NewExporter(source, ex.dest, ex.home.Logs(), ex.full)
 	if err != nil {
 		return fmt.Errorf("Unable to set up exporter: %s", err)
 	}
 	if err := exp.Export(); err != nil {
 		return err
+	}
+	if ex.verbose {
+		fmt.Fprintf(ex.out, "Export logs: %s\n", exp.Logs)
 	}
 	return nil
 }

--- a/pkg/packager/export.go
+++ b/pkg/packager/export.go
@@ -28,13 +28,14 @@ type Exporter struct {
 	Full        bool
 	Client      *client.Client
 	Context     context.Context
+	Logs        string
 }
 
 // NewExporter returns an *Exporter given information about where a bundle
 //  lives, where the compressed bundle should be exported to,
 //  and what form a bundle should be exported in (thin or thick/full). It also
 //  sets up a docker client to work with images.
-func NewExporter(source, dest string, full bool) (*Exporter, error) {
+func NewExporter(source, dest, logsDir string, full bool) (*Exporter, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err
@@ -45,12 +46,15 @@ func NewExporter(source, dest string, full bool) (*Exporter, error) {
 		return nil, fmt.Errorf("cannot negotation Docker client version: %v", err)
 	}
 
+	logs := filepath.Join(logsDir, "export-"+time.Now().Format("20060102150405"))
+
 	return &Exporter{
 		Source:      source,
 		Destination: dest,
 		Full:        full,
 		Client:      cli,
 		Context:     ctx,
+		Logs:        logs,
 	}, nil
 }
 
@@ -62,13 +66,20 @@ func NewExporter(source, dest string, full bool) (*Exporter, error) {
 func (ex *Exporter) Export() error {
 	l := loader.NewUnsignedLoader() // TODO: switch on flag
 
+	//prepare log file for this export
+	logsf, err := os.Create(ex.Logs)
+	if err != nil {
+		return err
+	}
+	defer logsf.Close()
+
 	bun, err := l.Load(filepath.Join(ex.Source, "bundle.json"))
 	if err != nil {
 		return fmt.Errorf("Error loading bundle: %s", err)
 	}
 
 	if ex.Full {
-		if err := ex.prepareArtifacts(bun); err != nil {
+		if err := ex.prepareArtifacts(bun, logsf); err != nil {
 			return fmt.Errorf("Error preparing artifacts: %s", err)
 		}
 	}
@@ -102,23 +113,23 @@ func (ex *Exporter) Export() error {
 	return err
 }
 
-// PrepareArtifacts pulls all images, verifies their digests (TODO: verify digest) and
+// prepareArtifacts pulls all images, verifies their digests (TODO: verify digest) and
 //  saves them to a directory called artifacts/ in the bundle directory
-func (ex *Exporter) prepareArtifacts(bun *bundle.Bundle) error {
+func (ex *Exporter) prepareArtifacts(bun *bundle.Bundle, logs io.Writer) error {
 	artifactsDir := filepath.Join(ex.Source, "artifacts")
 	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
 		return err
 	}
 
 	for _, image := range bun.Images {
-		_, err := ex.archiveImage(image.Image, artifactsDir)
+		_, err := ex.archiveImage(image.Image, artifactsDir, logs)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, in := range bun.InvocationImages {
-		_, err := ex.archiveImage(in.Image, artifactsDir)
+		_, err := ex.archiveImage(in.Image, artifactsDir, logs)
 		if err != nil {
 			return err
 		}
@@ -128,16 +139,16 @@ func (ex *Exporter) prepareArtifacts(bun *bundle.Bundle) error {
 	return nil
 }
 
-func (ex *Exporter) archiveImage(image, artifactsDir string) (string, error) {
+func (ex *Exporter) archiveImage(image, artifactsDir string, logs io.Writer) (string, error) {
 	ctx := ex.Context
 
 	imagePullOptions := types.ImagePullOptions{} //TODO: add platform info
-	_, err := ex.Client.ImagePull(ctx, image, imagePullOptions)
+	pullLogs, err := ex.Client.ImagePull(ctx, image, imagePullOptions)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Error pulling image: %s", err)
 	}
-	//TODO: verify digest after pull
-	time.Sleep(2 * time.Second) //TODO: get rid of this gah
+	defer pullLogs.Close()
+	io.Copy(logs, pullLogs)
 
 	reader, err := ex.Client.ImageSave(ctx, []string{image})
 	if err != nil {

--- a/pkg/packager/export_test.go
+++ b/pkg/packager/export_test.go
@@ -21,6 +21,7 @@ func TestExport(t *testing.T) {
 	ex := Exporter{
 		Source: source,
 		Full:   false,
+		Logs:   filepath.Join(tempDir, "export-logs"),
 	}
 
 	tempPWD, err := ioutil.TempDir("", "duffle-export-test")
@@ -60,6 +61,7 @@ func TestExportCreatesFileProperly(t *testing.T) {
 		Source:      "testdata/examplebun",
 		Destination: filepath.Join(tempDir, "random-directory", "examplebun-whatev.tgz"),
 		Full:        false,
+		Logs:        filepath.Join(tempDir, "export-logs"),
 	}
 
 	if err := ex.Export(); err == nil {


### PR DESCRIPTION
We were not waiting for the image to be pulled
before going on to the next step and exiting the
archiveImage function. This caused the image to
not be pulled. There used to be a sleep as a temp
fix to the problem but sleep is fragile and never
was intended as a long term solution.

This solution logs the image pull output ensuring
that we wait until the image is pulled before
moving on to the next step which is saveing the
image archive.

It also adds a verbose flag to the export cmd which
when enabled shows users the path of the logs file
for that export.

resolves #468