### PR TITLE
fix(*): properly load images on import

### DIFF
--- a/cmd/duffle/import.go
+++ b/cmd/duffle/import.go
@@ -21,6 +21,7 @@ type importCmd struct {
 	out      io.Writer
 	home     home.Home
 	insecure bool
+	verbose  bool
 }
 
 func newImportCmd(w io.Writer) *cobra.Command {
@@ -46,6 +47,7 @@ func newImportCmd(w io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&importc.dest, "destination", "d", "", "Location to unpack bundle")
 	f.BoolVarP(&importc.insecure, "insecure", "k", false, "Do not verify the bundle (INSECURE)")
+	f.BoolVarP(&importc.verbose, "verbose", "v", false, "Verbose output")
 
 	return cmd
 }
@@ -66,7 +68,7 @@ func (im *importCmd) run() error {
 		return err
 	}
 
-	imp, err := packager.NewImporter(source, dest, l)
+	imp, err := packager.NewImporter(source, dest, l, im.verbose)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Import was not properly loading images because
the filepath.Walk function was opening the
archives directory like it was a file and then
passing that into the ImageLoad function which
failed silently.

This code change does two things:
1. It checks os.FileInfo to see if the path is
a directory and returns if it is. If the path is not
a directory, it proceeds to import the image archive
file.
2. It adds a verbose flag to the import command. If
enabled, it streams the ouput from image load to stdout.

resolves #469