### PR TITLE
Fix string length validation error printing pointers not values

### DIFF
--- a/pkg/bundle/parameters.go
+++ b/pkg/bundle/parameters.go
@@ -125,10 +125,10 @@ func (pd ParameterDefinition) validateStringParameterValue(value interface{}) er
 		return errors.New("value is not a string")
 	}
 	if pd.MinLength != nil && len(s) < *pd.MinLength {
-		return fmt.Errorf("value is too short: minimum length is %d", pd.MinLength)
+		return fmt.Errorf("value is too short: minimum length is %d", *pd.MinLength)
 	}
 	if pd.MaxLength != nil && len(s) > *pd.MaxLength {
-		return fmt.Errorf("value is too long: maximum length is %d", pd.MaxLength)
+		return fmt.Errorf("value is too long: maximum length is %d", *pd.MaxLength)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #496.

The corresponding message for integer value min/max validation already dereferences its pointers so no fix needed there - I think that might have been the one you previously found and fixed @technosophos.