### PR TITLE
fix(credentials): disallow credentialset names with invalid characters

### DIFF
--- a/cmd/duffle/credential_generate.go
+++ b/cmd/duffle/credential_generate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	survey "gopkg.in/AlecAivazis/survey.v1"
@@ -108,6 +109,10 @@ func genCredentialSet(name string, creds map[string]bundle.Location, fn credenti
 		Name: name,
 	}
 	cs.Credentials = []credentials.CredentialStrategy{}
+
+	if strings.ContainsAny(name, "./\\") {
+		return cs, fmt.Errorf("credentialset name '%s' cannot contain the following characters: './\\'", name)
+	}
 
 	for name := range creds {
 		c, err := fn(name)

--- a/cmd/duffle/credential_generate_test.go
+++ b/cmd/duffle/credential_generate_test.go
@@ -37,3 +37,19 @@ func TestGenCredentialSet(t *testing.T) {
 		is.True(v, "%q not found", k)
 	}
 }
+
+func TestGenCredentialSetBadName(t *testing.T) {
+	testcases := []string{
+		"period.",
+		"forwardslash/",
+		"backslash\\",
+		"all.of.the/above\\",
+	}
+	for _, tc := range testcases {
+		t.Run(tc, func(t *testing.T) {
+			is := assert.New(t)
+			_, err := genCredentialSet(tc, nil, genEmptyCredentials)
+			is.Error(err)
+		})
+	}
+}


### PR DESCRIPTION
fixes #283 

cc @itowlson as this probably affects the VSCode extension. We probably want to sanitize names or prompt for a name of the credentialset (if we don't already since this bug was reported)

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>