### PR TITLE
fix(bundle_sign.go): properly set default user

### DIFF
--- a/cmd/duffle/bundle_sign.go
+++ b/cmd/duffle/bundle_sign.go
@@ -71,6 +71,7 @@ func bundleFileOrArg1(args []string, bundle string) (string, error) {
 	}
 	return bundle, nil
 }
+
 func (bs *bundleSignCmd) signBundle(bundleFile, keyring string) error {
 	// Verify that file exists
 	if fi, err := os.Stat(bundleFile); err != nil {
@@ -114,6 +115,12 @@ func (bs *bundleSignCmd) signBundle(bundleFile, keyring string) error {
 		k = all[0]
 	}
 
+	// Be sure userID is parseable before attempting to sign
+	userID, err := k.UserID()
+	if err != nil {
+		return err
+	}
+
 	// Sign the file
 	s := signature.NewSigner(k)
 	data, err := s.Clearsign(b)
@@ -144,10 +151,6 @@ func (bs *bundleSignCmd) signBundle(bundleFile, keyring string) error {
 		return err
 	}
 
-	userID, err := k.UserID()
-	if err != nil {
-		return err
-	}
 	fmt.Fprintf(bs.out, "Signed by %s %s \n", userID.String(), k.Fingerprint())
 	return nil
 }

--- a/cmd/duffle/default_user.go
+++ b/cmd/duffle/default_user.go
@@ -20,11 +20,13 @@ func defaultUserID() signature.UserID {
 
 	if account, err := user.Current(); err != nil {
 		name = "user"
+		username = name
 	} else {
 		name = account.Name
 		username = account.Username
 	}
-	// on Windows, account name are prefixed with '<machinename>\' which makes the generated email invalid
+
+	// on Windows, account names are prefixed with '<machinename>\' which makes the generated email invalid
 	// and makes the key user identity parser fail
 	if ix := strings.Index(username, "\\"); ix != -1 {
 		username = username[ix+1:]

--- a/cmd/duffle/init.go
+++ b/cmd/duffle/init.go
@@ -199,7 +199,6 @@ func (i *initCmd) loadOrCreateSecretKeyRing(dest string) (*signature.KeyRing, er
 			}
 		} else {
 			user = defaultUserID()
-
 		}
 		// Generate the key
 		fmt.Fprintf(i.w, "==> Generating a new signing key with ID %s\n", user.String())


### PR DESCRIPTION
- set `username` in addition to `name` if `user.Current()` errors out
- prevent signing/writing file if user not parseable (previously, command would both error out _and_ write file when `-o file` supplied)

Fixes https://github.com/deislabs/duffle/issues/499 (pending confirmation from @itowlson)