### PR TITLE
Docker driver fixes

### DIFF
--- a/pkg/driver/docker_driver.go
+++ b/pkg/driver/docker_driver.go
@@ -93,7 +93,7 @@ func (nullWriter) Write(b []byte) (int, error) {
 func (d *DockerDriver) exec(op *Operation) error {
 	ctx := context.Background()
 	var cliout, clierr io.Writer = os.Stdout, os.Stderr
-	if _, ok := d.config["DOCKER_DRIVER_QUIET"]; ok {
+	if d.config["DOCKER_DRIVER_QUIET"] == "1" {
 		cliout = nullWriter{}
 		clierr = nullWriter{}
 	}


### PR DESCRIPTION
This adds a quiet mode to the driver, initializing the CLI struct with a nullwriter so that pulls get silent.
This also makes sure stderr from invocation image is correctly streamed alongside stdout.