### PR TITLE
feat(create): fill out maintainers and keywords fields

### DIFF
--- a/cmd/duffle/create_test.go
+++ b/cmd/duffle/create_test.go
@@ -48,8 +48,23 @@ func TestCreateCmd(t *testing.T) {
     "name": "test-bundle",
     "version": "0.1.0",
     "description": "A short description of your bundle",
-    "keywords": null,
-    "maintainers": null,
+    "keywords": [
+        "test-bundle",
+        "cnab",
+        "tutorial"
+    ],
+    "maintainers": [
+        {
+            "name": "John Doe",
+            "email": "john.doe@example.com",
+            "url": "https://example.com"
+        },
+        {
+            "name": "Jane Doe",
+            "email": "jane.doe@example.com",
+            "url": "https://example.com"
+        }
+    ],
     "components": {
         "cnab": {
             "name": "cnab",

--- a/pkg/duffle/manifest/create.go
+++ b/pkg/duffle/manifest/create.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/deislabs/duffle/pkg/bundle"
 )
 
 const runContent = `#!/bin/bash
@@ -35,6 +37,19 @@ func Scaffold(path string) error {
 		Name:        name,
 		Version:     "0.1.0",
 		Description: "A short description of your bundle",
+		Keywords:    []string{name, "cnab", "tutorial"},
+		Maintainers: []bundle.Maintainer{
+			{
+				Name:  "John Doe",
+				Email: "john.doe@example.com",
+				URL:   "https://example.com",
+			},
+			{
+				Name:  "Jane Doe",
+				Email: "jane.doe@example.com",
+				URL:   "https://example.com",
+			},
+		},
 		Components: map[string]*Component{
 			"cnab": {
 				Name:    "cnab",


### PR DESCRIPTION
This gives the first-time user more information on what should be entered in these fields.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>