### PR TITLE
ref(create): switch default registry to deislabs

### DIFF
--- a/cmd/duffle/create_test.go
+++ b/cmd/duffle/create_test.go
@@ -55,7 +55,7 @@ func TestCreateCmd(t *testing.T) {
             "name": "cnab",
             "builder": "docker",
             "configuration": {
-                "registry": "microsoft"
+                "registry": "deislabs"
             }
         }
     },

--- a/pkg/duffle/manifest/create.go
+++ b/pkg/duffle/manifest/create.go
@@ -40,7 +40,7 @@ func Scaffold(path string) error {
 				Name:    "cnab",
 				Builder: "docker",
 				Configuration: map[string]string{
-					"registry": "microsoft",
+					"registry": "deislabs",
 				},
 			},
 		},


### PR DESCRIPTION
personal preference, but it's slightly less corporate. IMO I think it might be better if we removed this field by default, but there is value in showing how the `configuration` field works. Is there any field similar to `registry` that duffle understands at this time which we can use to replace this field?

Feel free to close if I'm just painting the bike shed a different colour. 😄

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>