### PR TITLE
fix(create): omit empty fields from `duffle create`

### DIFF
--- a/cmd/duffle/create_test.go
+++ b/cmd/duffle/create_test.go
@@ -73,9 +73,7 @@ func TestCreateCmd(t *testing.T) {
                 "registry": "deislabs"
             }
         }
-    },
-    "parameters": null,
-    "credentials": null
+    }
 }`
 	if string(mbytes) != expected {
 		t.Errorf("Expected duffle.json output to look like this:\n\n%s\n\nGot:\n\n%s", expected, string(mbytes))

--- a/pkg/duffle/manifest/manifest.go
+++ b/pkg/duffle/manifest/manifest.go
@@ -13,13 +13,13 @@ import (
 type Manifest struct {
 	Name             string                                `json:"name" mapstructure:"name"`
 	Version          string                                `json:"version" mapstructure:"version"`
-	Description      string                                `json:"description" mapstructure:"description"`
-	Keywords         []string                              `json:"keywords" mapstructure:"keywords"`
-	Maintainers      []bundle.Maintainer                   `json:"maintainers" mapstructure:"maintainers"`
-	InvocationImages map[string]*InvocationImage           `json:"invocationImages" mapstructure:"invocationImages"`
+	Description      string                                `json:"description,omitempty" mapstructure:"description,omitempty"`
+	Keywords         []string                              `json:"keywords,omitempty" mapstructure:"keywords,omitempty"`
+	Maintainers      []bundle.Maintainer                   `json:"maintainers,omitempty" mapstructure:"maintainers,omitempty"`
+	InvocationImages map[string]*InvocationImage           `json:"invocationImages,omitempty" mapstructure:"invocationImages,omitempty"`
 	Actions          map[string]bundle.Action              `json:"actions,omitempty" mapstructure:"actions,omitempty"`
-	Parameters       map[string]bundle.ParameterDefinition `json:"parameters" mapstructure:"parameters"`
-	Credentials      map[string]bundle.Location            `json:"credentials" mapstructure:"credentials"`
+	Parameters       map[string]bundle.ParameterDefinition `json:"parameters,omitempty" mapstructure:"parameters,omitempty"`
+	Credentials      map[string]bundle.Location            `json:"credentials,omitempty" mapstructure:"credentials,omitempty"`
 }
 
 // InvocationImage represents an invocation image component of a CNAB bundle


### PR DESCRIPTION
conflicts with #557 since it adds a new field to duffle.json

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>