### PR TITLE
feat(install): omitting the tag now fetches the latest semver tag

### DIFF
--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -201,7 +201,12 @@ func getBundleFilepath(bun string, insecure bool) (string, error) {
 		return "", fmt.Errorf("cannot open %s: %v", home.Repositories(), err)
 	}
 
-	digest, err := index.Get(ref.Name(), ref.Tag())
+	tag := ref.Tag()
+	if ref.Tag() == "latest" {
+		tag = ""
+	}
+
+	digest, err := index.Get(ref.Name(), tag)
 	if err != nil {
 		return "", fmt.Errorf("could not find %s:%s in %s: %v", ref.Name(), ref.Tag(), home.Repositories(), err)
 	}

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -3,7 +3,10 @@ package repo
 import (
 	"bytes"
 	"reflect"
+	"sort"
 	"testing"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -44,7 +47,7 @@ func TestLoadIndexReader(t *testing.T) {
 	revs, ok := l.GetVersions("hub.cnlabs.io/goodbyeworld")
 	is.True(ok)
 	is.Len(revs, 2)
-	is.Equal("abcdefghijklmnop", revs["1.0.0"])
+	is.Equal("abcdefghijklmnop", revs[0].Digest)
 
 	is.True(l.Delete("hub.cnlabs.io/goodbyeworld"))
 	is.False(l.Has("hub.cnlabs.io/goodbyeworld", "1.0.0"))
@@ -53,4 +56,25 @@ func TestLoadIndexReader(t *testing.T) {
 	is.True(l.DeleteVersion("hub.cnlabs.io/helloworld", "2.0.0"))
 	is.True(l.Has("hub.cnlabs.io/helloworld", "1.0.0"))
 	is.False(l.Has("hub.cnlabs.io/helloworld", "2.0.0"))
+}
+
+func TestBundleVersionSortByVersion(t *testing.T) {
+	byVersion := ByVersion{
+		BundleVersion{
+			Version: semver.MustParse("0.1.0"),
+		},
+		BundleVersion{
+			Version: semver.MustParse("0.2.0"),
+		},
+	}
+
+	sort.Sort(byVersion)
+	if byVersion[0].Version.String() != "0.1.0" {
+		t.Errorf("expected 0.1.0, got %s", byVersion[0].Version.String())
+	}
+
+	sort.Sort(sort.Reverse(byVersion))
+	if byVersion[0].Version.String() != "0.2.0" {
+		t.Errorf("expected 0.2.0, got %s", byVersion[0].Version.String())
+	}
 }


### PR DESCRIPTION
Given that you have the following bundles:

```
$ duffle bundle list
NAME            VERSION DIGEST                                          SIGNED?
helloworld      0.2.0   1d613da00b103a54cbe58d033904b1b9df877c2f        true
helloworld      0.1.0   824475e97a798263d3edda6bd23a58057860d17f        true
```

`duffle bundle install test helloworld` will now install v0.2.0.

Note: this now puts a constraint upon duffle where storing non-semver compatible versions in the local store is considered invalid. This was already the case before with `duffle build`:

```
$ duffle build .\examples\helloworld\
Error: cannot prepare build: Invalid Semantic Version
```

This can be worked around with the `-f` flag, however.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>