### PR TITLE
Add image references in the Duffle build manifest

### DIFF
--- a/cmd/duffle/create_test.go
+++ b/cmd/duffle/create_test.go
@@ -74,6 +74,7 @@ func TestCreateCmd(t *testing.T) {
             }
         }
     },
+    "images": null,
     "parameters": null,
     "credentials": null
 }`

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -77,7 +77,7 @@ func (b *Builder) PrepareBuild(bldr *Builder, mfst *manifest.Manifest, appDir st
 	bf := &bundle.Bundle{
 		Name:        ctx.Manifest.Name,
 		Description: ctx.Manifest.Description,
-		Images:      []bundle.Image{},
+		Images:      mfst.Images,
 		Keywords:    ctx.Manifest.Keywords,
 		Maintainers: ctx.Manifest.Maintainers,
 		Parameters:  ctx.Manifest.Parameters,

--- a/pkg/duffle/manifest/manifest.go
+++ b/pkg/duffle/manifest/manifest.go
@@ -17,6 +17,7 @@ type Manifest struct {
 	Keywords         []string                              `json:"keywords" mapstructure:"keywords"`
 	Maintainers      []bundle.Maintainer                   `json:"maintainers" mapstructure:"maintainers"`
 	InvocationImages map[string]*InvocationImage           `json:"invocationImages" mapstructure:"invocationImages"`
+	Images           []bundle.Image                        `json:"images" mapstructure:"images"`
 	Parameters       map[string]bundle.ParameterDefinition `json:"parameters" mapstructure:"parameters"`
 	Credentials      map[string]bundle.Location            `json:"credentials" mapstructure:"credentials"`
 }


### PR DESCRIPTION
This PR adds an `images` section in the Duffle build manifest:

```
       │ File: duffle.json

   1   │ {
   2   │     "name": "foo",
   3   │     "version": "0.1.0",
   4   │     "description": "A short description of your bundle",
   5   │     "keywords": [
   6   │         "foo",
   7   │         "cnab",
   8   │         "tutorial"
   9   │     ],
  10   │     "maintainers": [
  11   │         {
  12   │             "name": "John Doe",
  13   │             "email": "john.doe@example.com",
  14   │             "url": "https://example.com"
  15   │         },
  16   │         {
  17   │             "name": "Jane Doe",
  18   │             "email": "jane.doe@example.com",
  19   │             "url": "https://example.com"
  20   │         }
  21   │     ],
  22   │     "invocationImages": {
  23   │         "cnab": {
  24   │             "name": "cnab",
  25   │             "builder": "docker",
  26   │             "configuration": {
  27   │                 "registry": "deislabs"
  28   │             }
  29   │         }
  30   │     },
  31   │     "images": [
  32   │         {
  33   │             "description": "alpine",
  34   │             "image": "technosophos/demo2alpine:0.1.0",
  35   │             "imageType": "docker",
  36   │             "refs": [
  37   │                 {
  38   │                     "path": "cnab/app/charts/alpine/values.yaml",
  39   │                     "field": "image.repository"
  40   │                 }
  41   │             ]
  42   │         }
  43   │     ],
  44   │     "parameters": null,
  45   │     "credentials": null
  46   │ }
```

At this point, the build manifest uses exactly the same structure as the bundle manifest itself, so there are no inconsistencies.

depends on #561