### PR TITLE
Fix docs on how to build OS/arch-specific binaries

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -57,7 +57,7 @@ $ make build-all-bins
 To build for one specific OS / architecture:
 
 ```console
-$ OS=<desired OS> ARCH=<desired architecture> make build-bin
+$ GOOS=<desired OS> GOARCH=<desired architecture> make build-bin
 ```
 
 For convenience, you can build for the OS of your choice with amd64 architecture


### PR DESCRIPTION
Small change. PR #766 changed env vars to GOOS and GOARCH but must have forgotten to update docs.