### PR TITLE
Add certificate verification flags for relocate subcommand

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -736,17 +736,19 @@
   version = "v3.0.0"
 
 [[projects]]
-  digest = "1:b63982d7e9a99a2446f1dc931376d69615b73fac5bf7fda9853e39fd91d64906"
+  digest = "1:3c80328ae530489ae3f65ff9eeecd64eb339bf3c73c94ea40dca6117ee2bb408"
   name = "github.com/pivotal/image-relocation"
   packages = [
     "pkg/image",
     "pkg/pathmapping",
     "pkg/registry",
     "pkg/registry/ggcr",
+    "pkg/registry/ggcr/path",
+    "pkg/transport",
   ]
   pruneopts = "NUT"
-  revision = "28a4e87a740db9ee4e0b105ec6bef4210558df47"
-  version = "v0.5"
+  revision = "912b6a616466db58504fee9a614a3ee23dbbca6c"
+  version = "v0.8"
 
 [[projects]]
   digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
@@ -1278,6 +1280,7 @@
     "github.com/pivotal/image-relocation/pkg/pathmapping",
     "github.com/pivotal/image-relocation/pkg/registry",
     "github.com/pivotal/image-relocation/pkg/registry/ggcr",
+    "github.com/pivotal/image-relocation/pkg/transport",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -849,12 +849,12 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:42e8c2456d7ec0f31e182c20022e74324c4da2cb3bd9069ff9b131fe33466308"
+  digest = "1:6e7bb8be062d38ec9e9222973e81835554bfa2181b9ab29ff206514bd44fe8d2"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   pruneopts = "NUT"
-  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
-  version = "v1.3.0"
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@
 
 [[constraint]]
   name = "github.com/pivotal/image-relocation"
-  version = "v0.5"
+  version = "v0.8"
 
 [[constraint]]
   name = "github.com/deislabs/cnab-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.2"
+  version = "1.4.0"
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"

--- a/cmd/duffle/relocate.go
+++ b/cmd/duffle/relocate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/deislabs/cnab-go/bundle/loader"
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/pathmapping"
+	"github.com/pivotal/image-relocation/pkg/transport"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -49,6 +51,8 @@ type relocateCmd struct {
 	repoPrefix        string
 	bundleIsFile      bool
 	relocationMapping string
+	skipTLSVerify     bool
+	caCertPaths       []string
 
 	// context
 	home home.Home
@@ -56,6 +60,7 @@ type relocateCmd struct {
 
 	// dependencies
 	mapping               pathmapping.PathMapping
+	transportConstructor  func([]string, bool) (*http.Transport, error)
 	imageStoreConstructor imagestore.Constructor
 	imageStore            imagestore.Store
 }
@@ -98,6 +103,8 @@ duffle relocate path/to/bundle.json --relocation-mapping path/to/relmap.json --r
 	cmd.MarkFlagRequired("relocation-mapping")
 	f.StringVarP(&relocate.repoPrefix, "repository-prefix", "p", "", "Prefix for relocated image names")
 	cmd.MarkFlagRequired("repository-prefix")
+	f.StringSliceVarP(&relocate.caCertPaths, "ca-cert-path", "", nil, "Path to CA certificate for verifying registry TLS certificates (can be repeated for multiple certificates)")
+	f.BoolVarP(&relocate.skipTLSVerify, "skip-tls-verify", "", false, "Skip TLS certificate verification for registries")
 
 	return cmd
 }
@@ -150,8 +157,15 @@ func (r *relocateCmd) setup() (*relocator.Relocator, func(), error) {
 		return nil, nop, err
 	}
 
-	r.imageStore, err = r.imageStoreConstructor(imagestore.WithArchiveDir(dest))
+	transport, err := transport.NewHttpTransport(r.caCertPaths, r.skipTLSVerify)
 	if err != nil {
+		return nil, nop, err
+	}
+
+	if r.imageStore, err = r.imageStoreConstructor(
+		imagestore.WithArchiveDir(dest),
+		imagestore.WithTransport(transport),
+	); err != nil {
 		return nil, nop, err
 	}
 

--- a/cmd/duffle/relocate.go
+++ b/cmd/duffle/relocate.go
@@ -91,6 +91,7 @@ duffle relocate path/to/bundle.json --relocation-mapping path/to/relmap.json --r
 			relocate.home = home.Home(homePath())
 
 			relocate.mapping = pathmapping.FlattenRepoPathPreserveTagDigest
+			relocate.transportConstructor = transport.NewHttpTransport
 			relocate.imageStoreConstructor = construction.NewLocatingConstructor()
 
 			return relocate.run()
@@ -157,7 +158,7 @@ func (r *relocateCmd) setup() (*relocator.Relocator, func(), error) {
 		return nil, nop, err
 	}
 
-	transport, err := transport.NewHttpTransport(r.caCertPaths, r.skipTLSVerify)
+	transport, err := r.transportConstructor(r.caCertPaths, r.skipTLSVerify)
 	if err != nil {
 		return nil, nop, err
 	}

--- a/cmd/duffle/relocate_test.go
+++ b/cmd/duffle/relocate_test.go
@@ -117,7 +117,7 @@ func relocateFileToFile(t *testing.T, bundle string, expectedErr error, archiveD
 			return testMapping(originalImage, t)
 		},
 		imageStoreConstructor: func(option ...imagestore.Option) (store imagestore.Store, e error) {
-			archiveDirStub(imagestore.Create(option...).ArchiveDir)
+			archiveDirStub(imagestore.CreateParams(option...).ArchiveDir)
 			return is, nil
 		},
 	}

--- a/cmd/duffle/relocate_test.go
+++ b/cmd/duffle/relocate_test.go
@@ -8,13 +8,16 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"strings"
+	"regexp"
 	"testing"
 
 	"github.com/pivotal/image-relocation/pkg/image"
+	"github.com/pivotal/image-relocation/pkg/pathmapping"
+	"github.com/pivotal/image-relocation/pkg/transport"
 
 	"github.com/deislabs/duffle/pkg/duffle/home"
 	"github.com/deislabs/duffle/pkg/imagestore"
+	"github.com/deislabs/duffle/pkg/imagestore/construction"
 	"github.com/deislabs/duffle/pkg/imagestore/imagestoremocks"
 )
 
@@ -33,48 +36,127 @@ const (
 	originalImageDigestB = "sha256:14d6134d892aeccb7e142557fe746ccd0a8f736a747c195ef04c9f3f0f0bbd49"
 )
 
-func TestRelocateFileToFileSupportedImageTypes(t *testing.T) {
-	relocateFileToFile(t, "testdata/relocate/bundle.json", nil, func(archiveDir string) {
-		if archiveDir != "" {
-			t.Fatalf("archiveDir was %q, expected %q", archiveDir, "")
-		}
-	})
+func TestRelocate(t *testing.T) {
+	tests := map[string]struct {
+		bundle                  string
+		expectedArchiveDirRegex string
+		expectedErr             error
+	}{
+		"from file": {
+			"testdata/relocate/bundle.json",
+			"^$",
+			nil,
+		},
+		"from file with unsupported image type": {
+			"testdata/relocate/bundle-with-unsupported-image-type.json",
+			"^$",
+			errors.New("cannot relocate image c with imageType c: only oci and docker image types are currently supported"),
+		},
+		"from archive": {
+			"testdata/relocate/testrelocate-0.1.tgz",
+			"^.*testrelocate-0\\.1$",
+			nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			homedir := mustCreateTempDir(t, "dufflehome")
+			defer os.RemoveAll(homedir)
+
+			workdir := mustCreateTempDir(t, "relocatetest")
+			defer os.RemoveAll(workdir)
+
+			relMapPath := filepath.Join(workdir, "relmap.json")
+
+			cmd := initRelocateCmd(tc.bundle, homedir, relMapPath)
+			cmd.mapping = pathMappingStub(t)
+			cmd.imageStoreConstructor = imageStoreConstructorStub(t, tc.expectedArchiveDirRegex)
+
+			err := cmd.run()
+
+			assertErrorMessagesMatch(t, err, tc.expectedErr)
+
+			if tc.expectedErr == nil {
+				assertRelocationMap(t, relMapPath)
+			}
+		})
+	}
 }
 
-func TestRelocateThickBundleToFileSupportedImageTypes(t *testing.T) {
-	relocateFileToFile(t, "testdata/relocate/testrelocate-0.1.tgz", nil, func(archiveDir string) {
-		expectedSuffix := "testrelocate-0.1"
-		if !strings.HasSuffix(archiveDir, expectedSuffix) {
-			t.Fatalf("archiveDir was %q, expected it to end with %q", archiveDir, expectedSuffix)
-		}
-	})
-}
-
-func TestRelocateFileToFileUnsupportedImageType(t *testing.T) {
-	relocateFileToFile(t, "testdata/relocate/bundle-with-unsupported-image-type.json", errors.New("cannot relocate image c with imageType c: only oci and docker image types are currently supported"), func(archiveDir string) {
-		if archiveDir != "" {
-			t.Fatalf("archiveDir was %q, expected %q", archiveDir, "")
-		}
-	})
-}
-
-func relocateFileToFile(t *testing.T, bundle string, expectedErr error, archiveDirStub func(archiveDir string)) {
-
-	duffleHome, err := ioutil.TempDir("", "dufflehome")
+func mustCreateTempDir(t *testing.T, prefix string) string {
+	dirname, err := ioutil.TempDir("", "dufflehome")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(duffleHome)
 
-	work, err := ioutil.TempDir("", "relocatetest")
+	return dirname
+}
+
+func initRelocateCmd(bundle, homedir, relMapPath string) *relocateCmd {
+	return &relocateCmd{
+		inputBundle:           bundle,
+		repoPrefix:            testRepositoryPrefix,
+		bundleIsFile:          true,
+		relocationMapping:     relMapPath,
+		home:                  home.Home(homedir),
+		out:                   ioutil.Discard,
+		mapping:               pathmapping.FlattenRepoPathPreserveTagDigest,
+		transportConstructor:  transport.NewHttpTransport,
+		imageStoreConstructor: construction.NewLocatingConstructor(),
+	}
+}
+
+func pathMappingStub(t *testing.T) pathmapping.PathMapping {
+	return func(repoPrefix string, originalImage image.Name) image.Name {
+		if repoPrefix != testRepositoryPrefix {
+			t.Fatalf("Unexpected repository prefix %s", repoPrefix)
+		}
+		return mockMapping(t, originalImage)
+	}
+}
+
+func imageStoreConstructorStub(t *testing.T, expectedArchiveDirRegex string) imagestore.Constructor {
+	return func(option ...imagestore.Option) (store imagestore.Store, e error) {
+		archiveDir := imagestore.CreateParams(option...).ArchiveDir
+
+		regex, err := regexp.Compile(expectedArchiveDirRegex)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !regex.MatchString(archiveDir) {
+			t.Fatalf("archiveDir %q does not match regex %q", archiveDir, expectedArchiveDirRegex)
+		}
+
+		return mockImageStore(t), nil
+	}
+}
+
+// naïve test mapping, preserving any tag and/or digest
+// Note: unlike the real mapping, this produces names with more than two slash-separated components.
+func mockMapping(t *testing.T, originalImage image.Name) image.Name {
+	rn, err := image.NewName(path.Join(testRepositoryPrefix, originalImage.Path(), "relocated"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(work)
+	if tag := originalImage.Tag(); tag != "" {
+		rn, err = rn.WithTag(tag)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if dig := originalImage.Digest(); dig != image.EmptyDigest {
+		rn, err = rn.WithDigest(dig)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return rn
+}
 
-	relMapPath := filepath.Join(work, "relmap.json")
-
-	is := &imagestoremocks.MockStore{
+func mockImageStore(t *testing.T) imagestore.Store {
+	return &imagestoremocks.MockStore{
 		PushStub: func(dig image.Digest, src image.Name, dst image.Name) error {
 			type pair struct {
 				first  string
@@ -99,44 +181,23 @@ func relocateFileToFile(t *testing.T, bundle string, expectedErr error, archiveD
 			return nil
 		},
 	}
+}
 
-	cmd := &relocateCmd{
-		inputBundle: bundle,
-
-		repoPrefix:        testRepositoryPrefix,
-		bundleIsFile:      true,
-		relocationMapping: relMapPath,
-
-		home: home.Home(duffleHome),
-		out:  ioutil.Discard,
-
-		mapping: func(repoPrefix string, originalImage image.Name) image.Name {
-			if repoPrefix != testRepositoryPrefix {
-				t.Fatalf("Unexpected repository prefix %s", repoPrefix)
-			}
-			return testMapping(originalImage, t)
-		},
-		imageStoreConstructor: func(option ...imagestore.Option) (store imagestore.Store, e error) {
-			archiveDirStub(imagestore.CreateParams(option...).ArchiveDir)
-			return is, nil
-		},
+func assertErrorMessagesMatch(t *testing.T, actualErr, expectedErr error) {
+	if (actualErr != nil && expectedErr != nil && actualErr.Error() != expectedErr.Error()) ||
+		((actualErr == nil || expectedErr == nil) && actualErr != expectedErr) {
+		t.Fatalf("unexpected error %v (expected %v)", actualErr, expectedErr)
 	}
+}
 
-	if err := cmd.run(); (err != nil && expectedErr != nil && err.Error() != expectedErr.Error()) ||
-		((err == nil || expectedErr == nil) && err != expectedErr) {
-		t.Fatalf("unexpected error %v (expected %v)", err, expectedErr)
-	}
-
-	if expectedErr != nil {
-		return
-	}
-
-	// check relocation mapping file
+func assertRelocationMap(t *testing.T, relMapPath string) {
 	data, err := ioutil.ReadFile(relMapPath)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	relMap := make(map[string]string)
+
 	err = json.Unmarshal(data, &relMap)
 	if err != nil {
 		t.Fatal(err)
@@ -149,29 +210,9 @@ func relocateFileToFile(t *testing.T, bundle string, expectedErr error, archiveD
 	}
 
 	if !reflect.DeepEqual(relMap, expectedRelMap) {
-		t.Fatalf("output relocation mapping file has unexpected content: %v (expected %v)",
-			relMap, expectedRelMap)
+		t.Fatalf(
+			"output relocation mapping file has unexpected content: %v (expected %v)",
+			relMap, expectedRelMap,
+		)
 	}
-}
-
-// naïve test mapping, preserving any tag and/or digest
-// Note: unlike the real mapping, this produces names with more than two slash-separated components.
-func testMapping(originalImage image.Name, t *testing.T) image.Name {
-	rn, err := image.NewName(path.Join(testRepositoryPrefix, originalImage.Path(), "relocated"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if tag := originalImage.Tag(); tag != "" {
-		rn, err = rn.WithTag(tag)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	if dig := originalImage.Digest(); dig != image.EmptyDigest {
-		rn, err = rn.WithDigest(dig)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	return rn
 }

--- a/pkg/imagestore/construction/construction.go
+++ b/pkg/imagestore/construction/construction.go
@@ -9,6 +9,11 @@ import (
 	"github.com/deislabs/duffle/pkg/imagestore/remote"
 )
 
+var (
+	locatingConstructorRemote    = remote.Create
+	locatingConstructorOciLayout = ocilayout.LocateOciLayout
+)
+
 // NewConstructor creates an image store constructor which will, if necessary, create archive contents.
 func NewConstructor(remoteRepos bool) (imagestore.Constructor, error) {
 	// infer the concrete type of the image store from the input parameters
@@ -21,11 +26,11 @@ func NewConstructor(remoteRepos bool) (imagestore.Constructor, error) {
 // NewLocatingConstructor creates an image store constructor which will, if necessary, find existing archive contents.
 func NewLocatingConstructor() imagestore.Constructor {
 	return func(options ...imagestore.Option) (imagestore.Store, error) {
-		parms := imagestore.Create(options...)
+		parms := imagestore.CreateParams(options...)
 		if thin(parms.ArchiveDir) {
-			return remote.Create()
+			return locatingConstructorRemote(options...)
 		}
-		return ocilayout.LocateOciLayout(parms.ArchiveDir)
+		return locatingConstructorOciLayout(options...)
 	}
 }
 

--- a/pkg/imagestore/construction/construction_test.go
+++ b/pkg/imagestore/construction/construction_test.go
@@ -1,0 +1,107 @@
+package construction
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deislabs/duffle/pkg/imagestore"
+	"github.com/deislabs/duffle/pkg/imagestore/imagestoremocks"
+)
+
+func TestNewLocatingConstructor(t *testing.T) {
+	var (
+		myLogWriter   = &imagestoremocks.MockWriter{}
+		myTransport   = &imagestoremocks.MockRoundTripper{}
+		myThickBundle = mustCreateThickBundleDir(t)
+	)
+
+	defer os.RemoveAll(myThickBundle)
+
+	tests := map[string]struct {
+		opts   []imagestore.Option
+		expect imagestore.Parameters
+	}{
+		"thick bundle": {
+			opts: []imagestore.Option{
+				imagestore.WithArchiveDir(myThickBundle),
+			},
+			expect: imagestore.Parameters{
+				ArchiveDir: myThickBundle,
+				Logs:       ioutil.Discard,
+				Transport:  http.DefaultTransport,
+			},
+		},
+		"thin bundle - default store options": {
+			opts: []imagestore.Option{},
+			expect: imagestore.Parameters{
+				ArchiveDir: "",
+				Logs:       ioutil.Discard,
+				Transport:  http.DefaultTransport,
+			},
+		},
+		"thin bundle - custom transport": {
+			opts: []imagestore.Option{
+				imagestore.WithTransport(myTransport),
+			},
+			expect: imagestore.Parameters{
+				ArchiveDir: "",
+				Logs:       ioutil.Discard,
+				Transport:  myTransport,
+			},
+		},
+		"thin bundle - custom log writer": {
+			opts: []imagestore.Option{
+				imagestore.WithLogs(myLogWriter),
+			},
+			expect: imagestore.Parameters{
+				ArchiveDir: "",
+				Logs:       myLogWriter,
+				Transport:  http.DefaultTransport,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var (
+				remoteConstructorCalled    = false
+				ocilayoutConstructorCalled = false
+			)
+
+			locatingConstructorRemote = func(opts ...imagestore.Option) (imagestore.Store, error) {
+				remoteConstructorCalled = true
+				assert.Equal(t, tc.expect, imagestore.CreateParams(opts...))
+				return nil, nil
+			}
+
+			locatingConstructorOciLayout = func(opts ...imagestore.Option) (imagestore.Store, error) {
+				ocilayoutConstructorCalled = true
+				assert.Equal(t, tc.expect, imagestore.CreateParams(opts...))
+				return nil, nil
+			}
+
+			NewLocatingConstructor()(tc.opts...)
+
+			assert.Equal(t, tc.expect.ArchiveDir == "", remoteConstructorCalled)
+			assert.Equal(t, tc.expect.ArchiveDir != "", ocilayoutConstructorCalled)
+		})
+	}
+}
+
+func mustCreateThickBundleDir(t *testing.T) string {
+	name, err := ioutil.TempDir("", "bundle")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = os.Mkdir(filepath.Join(name, "artifacts"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	return name
+}

--- a/pkg/imagestore/imagestoremocks/store.go
+++ b/pkg/imagestore/imagestoremocks/store.go
@@ -1,6 +1,10 @@
 package imagestoremocks
 
-import "github.com/pivotal/image-relocation/pkg/image"
+import (
+	"net/http"
+
+	"github.com/pivotal/image-relocation/pkg/image"
+)
 
 type MockStore struct {
 	AddStub  func(im string) (string, error)
@@ -13,4 +17,16 @@ func (i *MockStore) Add(im string) (string, error) {
 
 func (i *MockStore) Push(dig image.Digest, src image.Name, dst image.Name) error {
 	return i.PushStub(dig, src, dst)
+}
+
+type MockRoundTripper struct{}
+
+func (r *MockRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+type MockWriter struct{}
+
+func (w *MockWriter) Write(p []byte) (n int, err error) {
+	return 0, nil
 }

--- a/pkg/imagestore/ocilayout/ocilayout.go
+++ b/pkg/imagestore/ocilayout/ocilayout.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/registry"
-	"github.com/pivotal/image-relocation/pkg/registry/ggcr"
 
 	"github.com/deislabs/duffle/pkg/imagestore"
 )
@@ -20,14 +19,14 @@ type ociLayout struct {
 }
 
 func Create(options ...imagestore.Option) (imagestore.Store, error) {
-	parms := imagestore.Create(options...)
+	parms := imagestore.CreateParams(options...)
 
 	layoutDir := filepath.Join(parms.ArchiveDir, "artifacts", "layout")
 	if err := os.MkdirAll(layoutDir, 0755); err != nil {
 		return nil, err
 	}
 
-	layout, err := ggcr.NewRegistryClient().NewLayout(layoutDir)
+	layout, err := parms.RegistryClient().NewLayout(layoutDir)
 	if err != nil {
 		return nil, err
 	}
@@ -38,12 +37,15 @@ func Create(options ...imagestore.Option) (imagestore.Store, error) {
 	}, nil
 }
 
-func LocateOciLayout(archiveDir string) (imagestore.Store, error) {
-	layoutDir := filepath.Join(archiveDir, "artifacts", "layout")
+func LocateOciLayout(options ...imagestore.Option) (imagestore.Store, error) {
+	parms := imagestore.CreateParams(options...)
+
+	layoutDir := filepath.Join(parms.ArchiveDir, "artifacts", "layout")
 	if _, err := os.Stat(layoutDir); os.IsNotExist(err) {
 		return nil, err
 	}
-	layout, err := ggcr.NewRegistryClient().ReadLayout(layoutDir)
+
+	layout, err := parms.RegistryClient().ReadLayout(layoutDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imagestore/remote/remote.go
+++ b/pkg/imagestore/remote/remote.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/registry"
-	"github.com/pivotal/image-relocation/pkg/registry/ggcr"
 
 	"github.com/deislabs/duffle/pkg/imagestore"
 )
@@ -15,9 +14,9 @@ type remote struct {
 	registryClient registry.Client
 }
 
-func Create(...imagestore.Option) (imagestore.Store, error) {
+func Create(options ...imagestore.Option) (imagestore.Store, error) {
 	return &remote{
-		registryClient: ggcr.NewRegistryClient(),
+		registryClient: imagestore.CreateParams(options...).RegistryClient(),
 	}, nil
 }
 

--- a/pkg/imagestore/store.go
+++ b/pkg/imagestore/store.go
@@ -3,8 +3,11 @@ package imagestore
 import (
 	"io"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/pivotal/image-relocation/pkg/image"
+	"github.com/pivotal/image-relocation/pkg/registry"
+	"github.com/pivotal/image-relocation/pkg/registry/ggcr"
 )
 
 // Store is an abstract image store.
@@ -24,12 +27,22 @@ type Constructor func(...Option) (Store, error)
 type Parameters struct {
 	ArchiveDir string
 	Logs       io.Writer
+	Transport  http.RoundTripper
+}
+
+// RegistryClient returns a properly configured ggcr client.
+func (p Parameters) RegistryClient() registry.Client {
+	if p.Transport != nil {
+		return ggcr.NewRegistryClient(ggcr.WithTransport(p.Transport))
+	}
+
+	return ggcr.NewRegistryClient()
 }
 
 // Options is a function which returns updated parameters.
 type Option func(Parameters) Parameters
 
-func Create(options ...Option) Parameters {
+func CreateParams(options ...Option) Parameters {
 	b := Parameters{
 		Logs: ioutil.Discard,
 	}
@@ -39,22 +52,35 @@ func Create(options ...Option) Parameters {
 	return b
 }
 
-// WithArchiveDir return an option to set the archive directory parameter.
+// WithArchiveDir returns an option to set the archive directory parameter.
 func WithArchiveDir(archiveDir string) Option {
 	return func(b Parameters) Parameters {
 		return Parameters{
 			ArchiveDir: archiveDir,
 			Logs:       b.Logs,
+			Transport:  b.Transport,
 		}
 	}
 }
 
-// WithArchiveDir return an option to set the logs parameter.
+// WithLogs returns an option to set the logs parameter.
 func WithLogs(logs io.Writer) Option {
 	return func(b Parameters) Parameters {
 		return Parameters{
 			ArchiveDir: b.ArchiveDir,
 			Logs:       logs,
+			Transport:  b.Transport,
+		}
+	}
+}
+
+// WithTransport returns an option to set the http transport for communication with remote registries.
+func WithTransport(transport http.RoundTripper) Option {
+	return func(b Parameters) Parameters {
+		return Parameters{
+			ArchiveDir: b.ArchiveDir,
+			Logs:       b.Logs,
+			Transport:  transport,
 		}
 	}
 }

--- a/pkg/imagestore/store.go
+++ b/pkg/imagestore/store.go
@@ -44,7 +44,8 @@ type Option func(Parameters) Parameters
 
 func CreateParams(options ...Option) Parameters {
 	b := Parameters{
-		Logs: ioutil.Discard,
+		Logs:      ioutil.Discard,
+		Transport: http.DefaultTransport,
 	}
 	for _, op := range options {
 		b = op(b)

--- a/pkg/imagestore/store_test.go
+++ b/pkg/imagestore/store_test.go
@@ -1,0 +1,59 @@
+package imagestore
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deislabs/duffle/pkg/imagestore/imagestoremocks"
+)
+
+func TestCreateParams(t *testing.T) {
+	var (
+		myLogWriter = &imagestoremocks.MockWriter{}
+		myTransport = &imagestoremocks.MockRoundTripper{}
+	)
+
+	tests := map[string]struct {
+		in  []Option
+		out Parameters
+	}{
+		"defaults": {
+			in:  nil,
+			out: Parameters{"", ioutil.Discard, http.DefaultTransport},
+		},
+		"custom log writer": {
+			in: []Option{
+				WithLogs(myLogWriter),
+			},
+			out: Parameters{
+				"", myLogWriter, http.DefaultTransport,
+			},
+		},
+		"custom transport": {
+			in: []Option{
+				WithTransport(myTransport),
+			},
+			out: Parameters{
+				"", ioutil.Discard, myTransport,
+			},
+		},
+		"multiple options": {
+			in: []Option{
+				WithTransport(myTransport),
+				WithLogs(myLogWriter),
+			},
+			out: Parameters{
+				"", myLogWriter, myTransport,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.out, CreateParams(tc.in...))
+		})
+	}
+}

--- a/pkg/packager/export_test.go
+++ b/pkg/packager/export_test.go
@@ -42,7 +42,7 @@ func TestExport(t *testing.T) {
 	ex := Exporter{
 		source: source,
 		imageStoreConstructor: func(option ...imagestore.Option) (store imagestore.Store, e error) {
-			parms := imagestore.Create(option...)
+			parms := imagestore.CreateParams(option...)
 			const expectedPrefix = "examplebun-0.1.0"
 			configArchiveDirBase := filepath.Base(parms.ArchiveDir)
 			if !strings.HasPrefix(configArchiveDirBase, expectedPrefix) {
@@ -94,7 +94,7 @@ func TestExportCreatesFileProperly(t *testing.T) {
 		source:      "testdata/examplebun/bundle.json",
 		destination: filepath.Join(tempDir, "random-directory", "examplebun-whatev.tgz"),
 		imageStoreConstructor: func(option ...imagestore.Option) (store imagestore.Store, e error) {
-			parms := imagestore.Create(option...)
+			parms := imagestore.CreateParams(option...)
 			const expectedPrefix = "examplebun-0.1.0"
 			configArchiveDirBase := filepath.Base(parms.ArchiveDir)
 			if !strings.HasPrefix(configArchiveDirBase, expectedPrefix) {

--- a/vendor/github.com/pivotal/image-relocation/pkg/registry/client.go
+++ b/vendor/github.com/pivotal/image-relocation/pkg/registry/client.go
@@ -37,4 +37,3 @@ type Client interface {
 	// OCI image layout.
 	ReadLayout(path string) (Layout, error)
 }
-

--- a/vendor/github.com/pivotal/image-relocation/pkg/registry/ggcr/path/layoutpath.go
+++ b/vendor/github.com/pivotal/image-relocation/pkg/registry/ggcr/path/layoutpath.go
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package registry
+package path
 
 import (
-	"github.com/pivotal/image-relocation/pkg/image"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 )
 
-// A Layout abstracts an OCI image layout on disk.
-type Layout interface {
-	// Add adds the image at the given image reference to the layout and returns the image's digest.
-	Add(n image.Name) (image.Digest, error)
-
-	// Push pushes the image with the given digest from the layout to the given image reference.
-	Push(digest image.Digest, name image.Name) error
-
-	// Find returns the digest of an image in the layout with the given image reference.
-	Find(n image.Name) (image.Digest, error)
+type LayoutPath interface {
+	AppendImage(img v1.Image, options ...layout.Option) error
+	AppendIndex(ii v1.ImageIndex, options ...layout.Option) error
+	ImageIndex() (v1.ImageIndex, error)
 }
 

--- a/vendor/github.com/pivotal/image-relocation/pkg/registry/image.go
+++ b/vendor/github.com/pivotal/image-relocation/pkg/registry/image.go
@@ -17,7 +17,6 @@
 package registry
 
 import (
-	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/pivotal/image-relocation/pkg/image"
 )
 
@@ -28,7 +27,4 @@ type Image interface {
 
 	// Write writes the image to a given reference and returns the image's digest and size.
 	Write(target image.Name) (image.Digest, int64, error)
-
-	// AppendToLayout appends the image to a given OCI image layout using the given layout options.
-	AppendToLayout(layoutPath LayoutPath, options ...layout.Option) error
 }

--- a/vendor/github.com/pivotal/image-relocation/pkg/transport/http.go
+++ b/vendor/github.com/pivotal/image-relocation/pkg/transport/http.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transport
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func NewHttpTransport(certs []string, insecureSkipVerify bool) (*http.Transport, error) {
+	transport := http.DefaultTransport.(*http.Transport)
+
+	if len(certs) > 0 || insecureSkipVerify {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: insecureSkipVerify,
+		}
+
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			pool = x509.NewCertPool()
+		}
+
+		for _, path := range certs {
+			pem, err := ioutil.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("could not read certificates from %q: %v", path, err)
+			}
+
+			if ok := pool.AppendCertsFromPEM(pem); !ok {
+				return nil, fmt.Errorf("could not append %q to certificate pool", path)
+			}
+		}
+
+		transport.TLSClientConfig.RootCAs = pool
+	}
+
+	return transport, nil
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_format.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_format.go
@@ -113,6 +113,17 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return Error(t, err, append([]interface{}{msg}, args...)...)
 }
 
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//    assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Eventually(t, condition, waitFor, tick, append([]interface{}{msg}, args...)...)
+}
+
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //    assert.Exactlyf(t, int32(123, "error message %s", "formatted"), int64(123))
@@ -155,6 +166,31 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) bool 
 		h.Helper()
 	}
 	return FileExists(t, path, append([]interface{}{msg}, args...)...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//    assert.Greaterf(t, 2, 1, "error message %s", "formatted")
+//    assert.Greaterf(t, float64(2, "error message %s", "formatted"), float64(1))
+//    assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Greater(t, e1, e2, append([]interface{}{msg}, args...)...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//    assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//    assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//    assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//    assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return GreaterOrEqual(t, e1, e2, append([]interface{}{msg}, args...)...)
 }
 
 // HTTPBodyContainsf asserts that a specified handler returns a
@@ -289,6 +325,14 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 	return JSONEq(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
+// YAMLEqf asserts that two YAML strings are equivalent.
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return YAMLEq(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
@@ -298,6 +342,31 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 		h.Helper()
 	}
 	return Len(t, object, length, append([]interface{}{msg}, args...)...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//    assert.Lessf(t, 1, 2, "error message %s", "formatted")
+//    assert.Lessf(t, float64(1, "error message %s", "formatted"), float64(2))
+//    assert.Lessf(t, "a", "b", "error message %s", "formatted")
+func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Less(t, e1, e2, append([]interface{}{msg}, args...)...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//    assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//    assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//    assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//    assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return LessOrEqual(t, e1, e2, append([]interface{}{msg}, args...)...)
 }
 
 // Nilf asserts that the specified object is nil.
@@ -442,6 +511,19 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 		h.Helper()
 	}
 	return Regexp(t, rx, str, append([]interface{}{msg}, args...)...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//    assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Same(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
 // Subsetf asserts that the specified list(array, slice...) contains all

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go
@@ -215,6 +215,28 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 	return Errorf(a.t, err, msg, args...)
 }
 
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//    a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//    a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Eventuallyf(a.t, condition, waitFor, tick, msg, args...)
+}
+
 // Exactly asserts that two objects are equal in value and type.
 //
 //    a.Exactly(int32(123), int64(123))
@@ -301,6 +323,56 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) b
 		h.Helper()
 	}
 	return FileExistsf(a.t, path, msg, args...)
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//    a.Greater(2, 1)
+//    a.Greater(float64(2), float64(1))
+//    a.Greater("b", "a")
+func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Greater(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//    a.GreaterOrEqual(2, 1)
+//    a.GreaterOrEqual(2, 2)
+//    a.GreaterOrEqual("b", "a")
+//    a.GreaterOrEqual("b", "b")
+func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//    a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//    a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//    a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//    a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return GreaterOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//    a.Greaterf(2, 1, "error message %s", "formatted")
+//    a.Greaterf(float64(2, "error message %s", "formatted"), float64(1))
+//    a.Greaterf("b", "a", "error message %s", "formatted")
+func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Greaterf(a.t, e1, e2, msg, args...)
 }
 
 // HTTPBodyContains asserts that a specified handler returns a
@@ -567,6 +639,22 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 	return JSONEqf(a.t, expected, actual, msg, args...)
 }
 
+// YAMLEq asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return YAMLEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return YAMLEqf(a.t, expected, actual, msg, args...)
+}
+
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
@@ -587,6 +675,56 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 		h.Helper()
 	}
 	return Lenf(a.t, object, length, msg, args...)
+}
+
+// Less asserts that the first element is less than the second
+//
+//    a.Less(1, 2)
+//    a.Less(float64(1), float64(2))
+//    a.Less("a", "b")
+func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Less(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//    a.LessOrEqual(1, 2)
+//    a.LessOrEqual(2, 2)
+//    a.LessOrEqual("a", "b")
+//    a.LessOrEqual("b", "b")
+func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return LessOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//    a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//    a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//    a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//    a.LessOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return LessOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//    a.Lessf(1, 2, "error message %s", "formatted")
+//    a.Lessf(float64(1, "error message %s", "formatted"), float64(2))
+//    a.Lessf("a", "b", "error message %s", "formatted")
+func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Lessf(a.t, e1, e2, msg, args...)
 }
 
 // Nil asserts that the specified object is nil.
@@ -875,6 +1013,32 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 		h.Helper()
 	}
 	return Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//    a.Same(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Same(a.t, expected, actual, msgAndArgs...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//    a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Samef(a.t, expected, actual, msg, args...)
 }
 
 // Subset asserts that the specified list(array, slice...) contains all

--- a/vendor/github.com/stretchr/testify/assert/assertion_order.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_order.go
@@ -1,0 +1,309 @@
+package assert
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
+	switch kind {
+	case reflect.Int:
+		{
+			intobj1 := obj1.(int)
+			intobj2 := obj2.(int)
+			if intobj1 > intobj2 {
+				return -1, true
+			}
+			if intobj1 == intobj2 {
+				return 0, true
+			}
+			if intobj1 < intobj2 {
+				return 1, true
+			}
+		}
+	case reflect.Int8:
+		{
+			int8obj1 := obj1.(int8)
+			int8obj2 := obj2.(int8)
+			if int8obj1 > int8obj2 {
+				return -1, true
+			}
+			if int8obj1 == int8obj2 {
+				return 0, true
+			}
+			if int8obj1 < int8obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Int16:
+		{
+			int16obj1 := obj1.(int16)
+			int16obj2 := obj2.(int16)
+			if int16obj1 > int16obj2 {
+				return -1, true
+			}
+			if int16obj1 == int16obj2 {
+				return 0, true
+			}
+			if int16obj1 < int16obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Int32:
+		{
+			int32obj1 := obj1.(int32)
+			int32obj2 := obj2.(int32)
+			if int32obj1 > int32obj2 {
+				return -1, true
+			}
+			if int32obj1 == int32obj2 {
+				return 0, true
+			}
+			if int32obj1 < int32obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Int64:
+		{
+			int64obj1 := obj1.(int64)
+			int64obj2 := obj2.(int64)
+			if int64obj1 > int64obj2 {
+				return -1, true
+			}
+			if int64obj1 == int64obj2 {
+				return 0, true
+			}
+			if int64obj1 < int64obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Uint:
+		{
+			uintobj1 := obj1.(uint)
+			uintobj2 := obj2.(uint)
+			if uintobj1 > uintobj2 {
+				return -1, true
+			}
+			if uintobj1 == uintobj2 {
+				return 0, true
+			}
+			if uintobj1 < uintobj2 {
+				return 1, true
+			}
+		}
+	case reflect.Uint8:
+		{
+			uint8obj1 := obj1.(uint8)
+			uint8obj2 := obj2.(uint8)
+			if uint8obj1 > uint8obj2 {
+				return -1, true
+			}
+			if uint8obj1 == uint8obj2 {
+				return 0, true
+			}
+			if uint8obj1 < uint8obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Uint16:
+		{
+			uint16obj1 := obj1.(uint16)
+			uint16obj2 := obj2.(uint16)
+			if uint16obj1 > uint16obj2 {
+				return -1, true
+			}
+			if uint16obj1 == uint16obj2 {
+				return 0, true
+			}
+			if uint16obj1 < uint16obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Uint32:
+		{
+			uint32obj1 := obj1.(uint32)
+			uint32obj2 := obj2.(uint32)
+			if uint32obj1 > uint32obj2 {
+				return -1, true
+			}
+			if uint32obj1 == uint32obj2 {
+				return 0, true
+			}
+			if uint32obj1 < uint32obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Uint64:
+		{
+			uint64obj1 := obj1.(uint64)
+			uint64obj2 := obj2.(uint64)
+			if uint64obj1 > uint64obj2 {
+				return -1, true
+			}
+			if uint64obj1 == uint64obj2 {
+				return 0, true
+			}
+			if uint64obj1 < uint64obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Float32:
+		{
+			float32obj1 := obj1.(float32)
+			float32obj2 := obj2.(float32)
+			if float32obj1 > float32obj2 {
+				return -1, true
+			}
+			if float32obj1 == float32obj2 {
+				return 0, true
+			}
+			if float32obj1 < float32obj2 {
+				return 1, true
+			}
+		}
+	case reflect.Float64:
+		{
+			float64obj1 := obj1.(float64)
+			float64obj2 := obj2.(float64)
+			if float64obj1 > float64obj2 {
+				return -1, true
+			}
+			if float64obj1 == float64obj2 {
+				return 0, true
+			}
+			if float64obj1 < float64obj2 {
+				return 1, true
+			}
+		}
+	case reflect.String:
+		{
+			stringobj1 := obj1.(string)
+			stringobj2 := obj2.(string)
+			if stringobj1 > stringobj2 {
+				return -1, true
+			}
+			if stringobj1 == stringobj2 {
+				return 0, true
+			}
+			if stringobj1 < stringobj2 {
+				return 1, true
+			}
+		}
+	}
+
+	return 0, false
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//    assert.Greater(t, 2, 1)
+//    assert.Greater(t, float64(2), float64(1))
+//    assert.Greater(t, "b", "a")
+func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	e1Kind := reflect.ValueOf(e1).Kind()
+	e2Kind := reflect.ValueOf(e2).Kind()
+	if e1Kind != e2Kind {
+		return Fail(t, "Elements should be the same type", msgAndArgs...)
+	}
+
+	res, isComparable := compare(e1, e2, e1Kind)
+	if !isComparable {
+		return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(e1)), msgAndArgs...)
+	}
+
+	if res != -1 {
+		return Fail(t, fmt.Sprintf("\"%v\" is not greater than \"%v\"", e1, e2), msgAndArgs...)
+	}
+
+	return true
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//    assert.GreaterOrEqual(t, 2, 1)
+//    assert.GreaterOrEqual(t, 2, 2)
+//    assert.GreaterOrEqual(t, "b", "a")
+//    assert.GreaterOrEqual(t, "b", "b")
+func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	e1Kind := reflect.ValueOf(e1).Kind()
+	e2Kind := reflect.ValueOf(e2).Kind()
+	if e1Kind != e2Kind {
+		return Fail(t, "Elements should be the same type", msgAndArgs...)
+	}
+
+	res, isComparable := compare(e1, e2, e1Kind)
+	if !isComparable {
+		return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(e1)), msgAndArgs...)
+	}
+
+	if res != -1 && res != 0 {
+		return Fail(t, fmt.Sprintf("\"%v\" is not greater than or equal to \"%v\"", e1, e2), msgAndArgs...)
+	}
+
+	return true
+}
+
+// Less asserts that the first element is less than the second
+//
+//    assert.Less(t, 1, 2)
+//    assert.Less(t, float64(1), float64(2))
+//    assert.Less(t, "a", "b")
+func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	e1Kind := reflect.ValueOf(e1).Kind()
+	e2Kind := reflect.ValueOf(e2).Kind()
+	if e1Kind != e2Kind {
+		return Fail(t, "Elements should be the same type", msgAndArgs...)
+	}
+
+	res, isComparable := compare(e1, e2, e1Kind)
+	if !isComparable {
+		return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(e1)), msgAndArgs...)
+	}
+
+	if res != 1 {
+		return Fail(t, fmt.Sprintf("\"%v\" is not less than \"%v\"", e1, e2), msgAndArgs...)
+	}
+
+	return true
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//    assert.LessOrEqual(t, 1, 2)
+//    assert.LessOrEqual(t, 2, 2)
+//    assert.LessOrEqual(t, "a", "b")
+//    assert.LessOrEqual(t, "b", "b")
+func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	e1Kind := reflect.ValueOf(e1).Kind()
+	e2Kind := reflect.ValueOf(e2).Kind()
+	if e1Kind != e2Kind {
+		return Fail(t, "Elements should be the same type", msgAndArgs...)
+	}
+
+	res, isComparable := compare(e1, e2, e1Kind)
+	if !isComparable {
+		return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(e1)), msgAndArgs...)
+	}
+
+	if res != 1 && res != 0 {
+		return Fail(t, fmt.Sprintf("\"%v\" is not less than or equal to \"%v\"", e1, e2), msgAndArgs...)
+	}
+
+	return true
+}

--- a/vendor/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pmezard/go-difflib/difflib"
+	yaml "gopkg.in/yaml.v2"
 )
 
 //go:generate go run ../_codegen/main.go -output-package=assert -template=assertion_format.go.tmpl
@@ -350,6 +351,37 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 }
 
+// Same asserts that two pointers reference the same object.
+//
+//    assert.Same(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	expectedPtr, actualPtr := reflect.ValueOf(expected), reflect.ValueOf(actual)
+	if expectedPtr.Kind() != reflect.Ptr || actualPtr.Kind() != reflect.Ptr {
+		return Fail(t, "Invalid operation: both arguments must be pointers", msgAndArgs...)
+	}
+
+	expectedType, actualType := reflect.TypeOf(expected), reflect.TypeOf(actual)
+	if expectedType != actualType {
+		return Fail(t, fmt.Sprintf("Pointer expected to be of type %v, but was %v",
+			expectedType, actualType), msgAndArgs...)
+	}
+
+	if expected != actual {
+		return Fail(t, fmt.Sprintf("Not same: \n"+
+			"expected: %p %#v\n"+
+			"actual  : %p %#v", expected, expected, actual, actual), msgAndArgs...)
+	}
+
+	return true
+}
+
 // formatUnequalValues takes two values of arbitrary types and returns string
 // representations appropriate to be presented to the user.
 //
@@ -479,14 +511,14 @@ func isEmpty(object interface{}) bool {
 	// collection types are empty when they have no element
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
 		return objValue.Len() == 0
-	// pointers are empty if nil or if the value they point to is empty
+		// pointers are empty if nil or if the value they point to is empty
 	case reflect.Ptr:
 		if objValue.IsNil() {
 			return true
 		}
 		deref := objValue.Elem().Interface()
 		return isEmpty(deref)
-	// for all other types, compare against the zero value
+		// for all other types, compare against the zero value
 	default:
 		zero := reflect.Zero(objValue.Type())
 		return reflect.DeepEqual(object, zero.Interface())
@@ -629,7 +661,7 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 func includeElement(list interface{}, element interface{}) (ok, found bool) {
 
 	listValue := reflect.ValueOf(list)
-	elementValue := reflect.ValueOf(element)
+	listKind := reflect.TypeOf(list).Kind()
 	defer func() {
 		if e := recover(); e != nil {
 			ok = false
@@ -637,11 +669,12 @@ func includeElement(list interface{}, element interface{}) (ok, found bool) {
 		}
 	}()
 
-	if reflect.TypeOf(list).Kind() == reflect.String {
+	if listKind == reflect.String {
+		elementValue := reflect.ValueOf(element)
 		return true, strings.Contains(listValue.String(), elementValue.String())
 	}
 
-	if reflect.TypeOf(list).Kind() == reflect.Map {
+	if listKind == reflect.Map {
 		mapKeys := listValue.MapKeys()
 		for i := 0; i < len(mapKeys); i++ {
 			if ObjectsAreEqual(mapKeys[i].Interface(), element) {
@@ -1337,6 +1370,24 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 	return Equal(t, expectedJSONAsInterface, actualJSONAsInterface, msgAndArgs...)
 }
 
+// YAMLEq asserts that two YAML strings are equivalent.
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	var expectedYAMLAsInterface, actualYAMLAsInterface interface{}
+
+	if err := yaml.Unmarshal([]byte(expected), &expectedYAMLAsInterface); err != nil {
+		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid yaml.\nYAML parsing error: '%s'", expected, err.Error()), msgAndArgs...)
+	}
+
+	if err := yaml.Unmarshal([]byte(actual), &actualYAMLAsInterface); err != nil {
+		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid yaml.\nYAML error: '%s'", actual, err.Error()), msgAndArgs...)
+	}
+
+	return Equal(t, expectedYAMLAsInterface, actualYAMLAsInterface, msgAndArgs...)
+}
+
 func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
 	t := reflect.TypeOf(v)
 	k := t.Kind()
@@ -1371,8 +1422,8 @@ func diff(expected interface{}, actual interface{}) string {
 		e = spewConfig.Sdump(expected)
 		a = spewConfig.Sdump(actual)
 	} else {
-		e = expected.(string)
-		a = actual.(string)
+		e = reflect.ValueOf(expected).String()
+		a = reflect.ValueOf(actual).String()
 	}
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
@@ -1413,4 +1464,35 @@ var spewConfig = spew.ConfigState{
 
 type tHelper interface {
 	Helper()
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//    assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	timer := time.NewTimer(waitFor)
+	ticker := time.NewTicker(tick)
+	checkPassed := make(chan bool)
+	defer timer.Stop()
+	defer ticker.Stop()
+	defer close(checkPassed)
+	for {
+		select {
+		case <-timer.C:
+			return Fail(t, "Condition never satisfied", msgAndArgs...)
+		case result := <-checkPassed:
+			if result {
+				return true
+			}
+		case <-ticker.C:
+			go func() {
+				checkPassed <- condition()
+			}()
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes #874 by adding:

* `--ca-cert-path` to `duffle relocate`
* `--skip-tls-verify` to `duffle relocate`

I believe we should add the same flags to `duffle export`. I'll create a separate issue for that.

As part of this PR, I added a bunch of unit tests. Since I didn't see any end-to-end tests in this repo, I manually verified that relocation actually works as expected using the script in [this gist](https://gist.github.com/st3v/c3ad062a3ab8755860bd594df5e34126). If you would like to run the same e2e tests, simply build duffle, put it in your path, and then run `sudo ./tls-test.sh setup` followed by `sudo ./tls-test.sh duffle`. 

Just for the record, following is the output from running my e2e test script.

```
try to relocate to private registry without specifying CA cert path, should fail
writing cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest
Error: failed to write image docker.io/cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest: failed to write image my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest: Get https://my-registry-1:5000/v2/: x509: certificate signed by unknown authority
PASSED

try to relocate to private registry with specifying correct CA cert path, should succeed
writing cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest
PASSED

try to relocate to private registry with specifying incorrect CA cert path, should fail
writing cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest
Error: failed to write image docker.io/cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest: failed to write image my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest: Get https://my-registry-1:5000/v2/: x509: certificate signed by unknown authority
PASSED

try to relocate to private registry without cert verification, should succeed
writing cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest
PASSED

try to relocate from/to private registry without specifying CA cert path for source, should fail
writing my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest to my-registry-2:5001/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a-02f8e960a10901897e7305066b3c40c0:latest
Error: failed to read image my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest: Get https://my-registry-1:5000/v2/: x509: certificate signed by unknown authority
PASSED

try to relocate from/to private registry without specifying CA cert path for destination, should fail
writing my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest to my-registry-2:5001/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a-02f8e960a10901897e7305066b3c40c0:latest
Error: failed to write image my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest to my-registry-2:5001/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a-02f8e960a10901897e7305066b3c40c0:latest: failed to write image my-registry-2:5001/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a-02f8e960a10901897e7305066b3c40c0:latest: Get https://my-registry-2:5001/v2/: x509: certificate signed by unknown authority
PASSED

try to relocate from/to private registry with specifying CA cert paths for both source and destination, should succeed
writing my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest to my-registry-2:5001/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a-02f8e960a10901897e7305066b3c40c0:latest
PASSED

try to relocate from/to private registry with specifying CA cert paths for both source and destination, should succeed
writing my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest to my-registry-2:5001/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a-02f8e960a10901897e7305066b3c40c0:latest
PASSED

try to relocate from/to private registry without cert verifictation, should succeed
writing my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest to my-registry-2:5001/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a-02f8e960a10901897e7305066b3c40c0:latest
PASSED

try to relocate images from thick bundle to private registry without specifying CA cert, should fail
writing cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest
Error: failed to write image sha256:55f83710272990efab4e076f9281453e136980becfd879640b06552ead751284 to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest: failed to write image my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest: Get https://my-registry-1:5000/v2/: x509: certificate signed by unknown authority
PASSED

try to relocate images from thick bundle to private registry with specifying CA cert, should succeed
writing cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest
PASSED

try to relocate images from thick bundle to private registry without cert verification, should succeed
writing cnab/helloworld:latest to my-registry-1:5000/cnab-helloworld-cf2fb20a6a55f18c0144591952a7013a:latest
PASSED
```