### PR TITLE
Update import paths for Duffle to `github.com/cnabio`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # Global Owners: These members are Core Maintainers of Duffle
 # Only certain critical files should cause all the owners to be added automatically to PR reviews
-# See https://github.com/deislabs/duffle/issues/745 for the rationale
+# See https://github.com/cnabio/duffle/issues/745 for the rationale
 CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @glyn @silvin-lubecki @jlegrone
 LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @glyn @silvin-lubecki @jlegrone
 NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @glyn @silvin-lubecki @jlegrone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/deis/lightweight-docker-go:v0.7.0
 ARG LDFLAGS
 ENV CGO_ENABLED=0
-WORKDIR /go/src/github.com/deislabs/duffle
+WORKDIR /go/src/github.com/cnabio/duffle
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 COPY vendor/ vendor/
@@ -9,5 +9,5 @@ RUN go build -ldflags "$LDFLAGS" -o bin/duffle ./cmd/...
 
 FROM alpine:3.8
 RUN apk add --no-cache bash make jq ca-certificates && update-ca-certificates
-COPY --from=0 /go/src/github.com/deislabs/duffle/bin/duffle /usr/bin/duffle
+COPY --from=0 /go/src/github.com/cnabio/duffle/bin/duffle /usr/bin/duffle
 CMD /usr/bin/duffle

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@
   non-go = true
   unused-packages = true
   go-tests = true
-  
+
 [[constraint]]
   name = "github.com/docker/go"
   version = "1.5.1-1"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 # Go build details                                                             #
 ################################################################################
 
-BASE_PACKAGE_NAME := github.com/deislabs/duffle
+BASE_PACKAGE_NAME := github.com/cnabio/duffle
 
 ################################################################################
 # Containerized development environment-- or lack thereof                      #
@@ -67,7 +67,7 @@ dep:
 
 .PHONY: goimports
 goimports:
-	$(DOCKER_CMD) sh -c "find . -name \"*.go\" | fgrep -v vendor/ | xargs goimports -w -local github.com/deislabs/duffle"
+	$(DOCKER_CMD) sh -c "find . -name \"*.go\" | fgrep -v vendor/ | xargs goimports -w -local github.com/cnabio/duffle"
 
 .PHONY: build-drivers
 build-drivers:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Learn more about about CNAB and Duffle, check out our [docs](docs/README.md).
 
 ## Getting Started
 
-1. [Get the latest Duffle release for your operating system](https://github.com/deislabs/duffle/releases).
+1. [Get the latest Duffle release for your operating system](https://github.com/cnabio/duffle/releases).
 
 
 2. Run the command to set `duffle` up on your machine:

--- a/brigade.js
+++ b/brigade.js
@@ -1,6 +1,6 @@
 const { events, Job, Group } = require("brigadier");
 
-const projectOrg = "deislabs";
+const projectOrg = "cnabio";
 const projectName = "duffle";
 
 const goImg = "quay.io/deis/lightweight-docker-go:v0.7.0";
@@ -55,7 +55,7 @@ function test() {
   job.mountPath = localPath;
   // Set a few environment variables.
   job.env = {
-      "SKIP_DOCKER": "true"
+    "SKIP_DOCKER": "true"
   };
   // Run Go unit tests
   job.tasks = [
@@ -125,7 +125,7 @@ function handleIssueComment(e, p) {
   comment = payload.body.comment.body.trim();
 
   // Here we determine if a comment should provoke an action
-  switch(comment) {
+  switch (comment) {
     case "/brig run":
       return runSuite(e, p);
     default:
@@ -145,7 +145,7 @@ function checkRequested(e, p) {
   name = payload.body.check_run.name;
 
   // Determine which check to run
-  switch(name) {
+  switch (name) {
     case "tests":
       return runTests(e, p);
     default:
@@ -186,7 +186,7 @@ class Notification {
     this.payload = e.payload;
     this.name = name;
     this.externalID = e.buildID;
-    this.detailsURL = `https://brigadecore.github.io/kashti/builds/${ e.buildID }`;
+    this.detailsURL = `https://brigadecore.github.io/kashti/builds/${e.buildID}`;
     this.title = "running check";
     this.text = "";
     this.summary = "";
@@ -202,7 +202,7 @@ class Notification {
   // Send a new notification, and return a Promise<result>.
   run() {
     this.count++;
-    var job = new Job(`${ this.name }-notification-${ this.count }`, "brigadecore/brigade-github-check-run:v0.1.0");
+    var job = new Job(`${this.name}-notification-${this.count}`, "brigadecore/brigade-github-check-run:v0.1.0");
     job.imageForcePull = true;
     job.env = {
       "CHECK_CONCLUSION": this.conclusion,
@@ -225,13 +225,13 @@ async function notificationWrap(job, note) {
     let res = await job.run();
     const logs = await job.logs();
     note.conclusion = "success";
-    note.summary = `Task "${ job.name }" passed`;
+    note.summary = `Task "${job.name}" passed`;
     note.text = "```" + res.toString() + "```\nTest Complete";
     return await note.run();
   } catch (e) {
     const logs = await job.logs();
     note.conclusion = "failure";
-    note.summary = `Task "${ job.name }" failed for ${ e.buildID }`;
+    note.summary = `Task "${job.name}" failed for ${e.buildID}`;
     note.text = "```" + logs + "```\nFailed with error: " + e.toString();
     try {
       await note.run();
@@ -242,4 +242,3 @@ async function notificationWrap(job, note) {
     throw e;
   }
 }
-

--- a/cmd/duffle/build.go
+++ b/cmd/duffle/build.go
@@ -19,15 +19,15 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/deislabs/duffle/pkg/builder"
-	"github.com/deislabs/duffle/pkg/crypto/digest"
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/duffle/manifest"
-	"github.com/deislabs/duffle/pkg/imagebuilder"
-	"github.com/deislabs/duffle/pkg/imagebuilder/docker"
-	"github.com/deislabs/duffle/pkg/imagebuilder/mock"
-	"github.com/deislabs/duffle/pkg/ohai"
-	"github.com/deislabs/duffle/pkg/repo"
+	"github.com/cnabio/duffle/pkg/builder"
+	"github.com/cnabio/duffle/pkg/crypto/digest"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/manifest"
+	"github.com/cnabio/duffle/pkg/imagebuilder"
+	"github.com/cnabio/duffle/pkg/imagebuilder/docker"
+	"github.com/cnabio/duffle/pkg/imagebuilder/mock"
+	"github.com/cnabio/duffle/pkg/ohai"
+	"github.com/cnabio/duffle/pkg/repo"
 )
 
 const buildDesc = `

--- a/cmd/duffle/build_test.go
+++ b/cmd/duffle/build_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/deislabs/duffle/pkg/repo"
+	"github.com/cnabio/duffle/pkg/repo"
 )
 
 func TestBuild(t *testing.T) {

--- a/cmd/duffle/bundle_actions.go
+++ b/cmd/duffle/bundle_actions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"

--- a/cmd/duffle/bundle_list.go
+++ b/cmd/duffle/bundle_list.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/repo"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/repo"
 )
 
 // NamedRepositoryList is a list of bundle references.

--- a/cmd/duffle/bundle_remove.go
+++ b/cmd/duffle/bundle_remove.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/repo"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/repo"
 
 	"github.com/Masterminds/semver"
 	"github.com/spf13/cobra"

--- a/cmd/duffle/bundle_remove_test.go
+++ b/cmd/duffle/bundle_remove_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 )
 
 func TestBundleRemove(t *testing.T) {

--- a/cmd/duffle/create.go
+++ b/cmd/duffle/create.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/duffle/manifest"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/manifest"
 )
 
 const createDesc = `

--- a/cmd/duffle/create_test.go
+++ b/cmd/duffle/create_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/duffle/manifest"
+	"github.com/cnabio/duffle/pkg/duffle/manifest"
 )
 
 func TestCreateCmd(t *testing.T) {

--- a/cmd/duffle/credential_add.go
+++ b/cmd/duffle/credential_add.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 
 	"github.com/deislabs/cnab-go/credentials"
 	log "github.com/sirupsen/logrus"

--- a/cmd/duffle/credential_add_test.go
+++ b/cmd/duffle/credential_add_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 )
 
 func TestCredentialAddFile(t *testing.T) {

--- a/cmd/duffle/credential_edit.go
+++ b/cmd/duffle/credential_edit.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/ghodss/yaml"

--- a/cmd/duffle/credential_generate.go
+++ b/cmd/duffle/credential_generate.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/credentials"

--- a/cmd/duffle/credential_list.go
+++ b/cmd/duffle/credential_list.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/gosuri/uitable"

--- a/cmd/duffle/credential_list_test.go
+++ b/cmd/duffle/credential_list_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 )
 
 func TestCredentialList(t *testing.T) {

--- a/cmd/duffle/credential_remove.go
+++ b/cmd/duffle/credential_remove.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 )
 
 type credentialRemoveCmd struct {

--- a/cmd/duffle/credential_remove_test.go
+++ b/cmd/duffle/credential_remove_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 )
 
 func TestCredentialRemove(t *testing.T) {

--- a/cmd/duffle/credential_show.go
+++ b/cmd/duffle/credential_show.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/ghodss/yaml"

--- a/cmd/duffle/export.go
+++ b/cmd/duffle/export.go
@@ -7,9 +7,9 @@ import (
 	"github.com/deislabs/cnab-go/bundle/loader"
 	"github.com/spf13/cobra"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/imagestore/construction"
-	"github.com/deislabs/duffle/pkg/packager"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/imagestore/construction"
+	"github.com/cnabio/duffle/pkg/packager"
 )
 
 const exportDesc = `

--- a/cmd/duffle/export_test.go
+++ b/cmd/duffle/export_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 )
 
 func setupTempDuffleHome(t *testing.T) (string, error) {

--- a/cmd/duffle/import.go
+++ b/cmd/duffle/import.go
@@ -8,8 +8,8 @@ import (
 	"github.com/deislabs/cnab-go/bundle/loader"
 	"github.com/spf13/cobra"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/packager"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/packager"
 )
 
 const importDesc = `

--- a/cmd/duffle/init.go
+++ b/cmd/duffle/init.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/ohai"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/ohai"
 )
 
 const (

--- a/cmd/duffle/install.go
+++ b/cmd/duffle/install.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/repo"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/repo"
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/bundle"

--- a/cmd/duffle/install_test.go
+++ b/cmd/duffle/install_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/deislabs/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 )
 
 func TestGetBundle(t *testing.T) {

--- a/cmd/duffle/main.go
+++ b/cmd/duffle/main.go
@@ -19,8 +19,8 @@ import (
 	"github.com/deislabs/cnab-go/utils/crud"
 	"github.com/spf13/cobra"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/reference"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/reference"
 )
 
 var (

--- a/cmd/duffle/main_test.go
+++ b/cmd/duffle/main_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/deislabs/cnab-go/driver"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/duffle/home"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/credentials"

--- a/cmd/duffle/relocate.go
+++ b/cmd/duffle/relocate.go
@@ -19,11 +19,11 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/imagestore"
-	"github.com/deislabs/duffle/pkg/imagestore/construction"
-	"github.com/deislabs/duffle/pkg/packager"
-	"github.com/deislabs/duffle/pkg/relocator"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore/construction"
+	"github.com/cnabio/duffle/pkg/packager"
+	"github.com/cnabio/duffle/pkg/relocator"
 )
 
 const (

--- a/cmd/duffle/relocate_test.go
+++ b/cmd/duffle/relocate_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/pivotal/image-relocation/pkg/pathmapping"
 	"github.com/pivotal/image-relocation/pkg/transport"
 
-	"github.com/deislabs/duffle/pkg/duffle/home"
-	"github.com/deislabs/duffle/pkg/imagestore"
-	"github.com/deislabs/duffle/pkg/imagestore/construction"
-	"github.com/deislabs/duffle/pkg/imagestore/imagestoremocks"
+	"github.com/cnabio/duffle/pkg/duffle/home"
+	"github.com/cnabio/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore/construction"
+	"github.com/cnabio/duffle/pkg/imagestore/imagestoremocks"
 )
 
 const (

--- a/cmd/duffle/root_test.go
+++ b/cmd/duffle/root_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/deislabs/cnab-go/bundle"
 
-	"github.com/deislabs/duffle/pkg/version"
+	"github.com/cnabio/duffle/pkg/version"
 )
 
 func TestHelpWrittenToStdout(t *testing.T) {

--- a/cmd/duffle/version.go
+++ b/cmd/duffle/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/deislabs/duffle/pkg/version"
+	"github.com/cnabio/duffle/pkg/version"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/duffle/version_test.go
+++ b/cmd/duffle/version_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/version"
+	"github.com/cnabio/duffle/pkg/version"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -4,8 +4,8 @@
 
 Cloning this repository and change directory to it:
 ```console
-$ go get -d github.com/deislabs/duffle/...
-$ cd $(go env GOPATH)/src/github.com/deislabs/duffle
+$ go get -d github.com/cnabio/duffle/...
+$ cd $(go env GOPATH)/src/github.com/cnabio/duffle
 ```
 
 ### Prerequisites
@@ -116,5 +116,4 @@ To create a release, simply push a tag and CI will do the rest. The tag should b
 ```
 Tags conform to [Semantic Versioning](https://semver.org/) in syntax and semantics, but must not start with `v`.
 
-Examples tags are: `0.3.0-beta.3` and `1.0.0`. 
-
+Examples tags are: `0.3.0-beta.3` and `1.0.0`.

--- a/docs/guides/bundle-guide.md
+++ b/docs/guides/bundle-guide.md
@@ -2,7 +2,7 @@
 
 A `bundle` is a CNAB package. In its slimmest form, a bundle contains metadata (in a `bundle.cnab` file) which points to a image (we call that the "invocation image") that contains instructions (in a `run` file) on how to install and configure a multi-component cloud native application.
 
-In this guide, you will create a CNAB bundle which does `echo` commands for various actions similar to the [helloworld](https://github.com/deislabs/duffle/blob/master/examples/helloworld/cnab/app/run) example.
+In this guide, you will create a CNAB bundle which does `echo` commands for various actions similar to the [helloworld](https://github.com/cnabio/duffle/blob/master/examples/helloworld/cnab/app/run) example.
 
 ## Create the Directory Structure
 

--- a/docs/proposal/200-duffle.md
+++ b/docs/proposal/200-duffle.md
@@ -57,7 +57,7 @@ For thick images, it will load the images into the local registry.
 
 For thin images, it will (if necessary) pull the dependent images from a registry and load them into the local Docker/Moby daemon.
 
-In the future, `duffle import` will also validate each Docker image's digest in an exported bundle, which is important to ensure that the docker images have not been tampered with. [Issue #392](https://github.com/deislabs/duffle/issues/392) discusses a solution for enforcing digest validation when importing a bundle.
+In the future, `duffle import` will also validate each Docker image's digest in an exported bundle, which is important to ensure that the docker images have not been tampered with. [Issue #392](https://github.com/cnabio/duffle/issues/392) discusses a solution for enforcing digest validation when importing a bundle.
 
 ## Passing Parameters into the Invocation Image
 

--- a/docs/proposal/204-export-import.md
+++ b/docs/proposal/204-export-import.md
@@ -49,5 +49,5 @@ cnab/wordpress      latest              533cfdfba95a        5 hours ago         
 ```
 
 ## Future Improvements
-- Handle non-docker images (issue [#513](https://github.com/deislabs/duffle/issues/513), [#494](https://github.com/deislabs/duffle/issues/494))
-- Handle exporting and importing from duffle's local bundle store (issue [#379](https://github.com/deislabs/duffle/issues/379))
+- Handle non-docker images (issue [#513](https://github.com/cnabio/duffle/issues/513), [#494](https://github.com/cnabio/duffle/issues/494))
+- Handle exporting and importing from duffle's local bundle store (issue [#379](https://github.com/cnabio/duffle/issues/379))

--- a/drivers/azure-vm/README.md
+++ b/drivers/azure-vm/README.md
@@ -38,7 +38,7 @@ Note that `imageType` is `azure-image` (indicating that it must be looked up in 
 ## Usage
 
 1. Run `make build-drivers`
-2. Add `$GOPATH/src/github.com/deislabs/duffle/bin` to your path
+2. Add `$GOPATH/src/github.com/cnabio/duffle/bin` to your path
 3. On the Duffle commands, set the driver to `azvm`
 
 ```console
@@ -74,5 +74,5 @@ To build images, install Packer, then edit `drivers/azure-vm/azure-packer.json`.
 From there, use something like this to build:
 
 ```console
-$ packer build -var-file keys.json azure-packer.json 
+$ packer build -var-file keys.json azure-packer.json
 ```

--- a/drivers/azure-vm/duffle-azvm.sh
+++ b/drivers/azure-vm/duffle-azvm.sh
@@ -7,7 +7,7 @@
 #
 # Note that STDIN gets passed to python, which injects it into the script.
 ############
-pydir=$GOPATH/src/github.com/deislabs/duffle/drivers/azure-vm
+pydir=$GOPATH/src/github.com/cnabio/duffle/drivers/azure-vm
 
 if [[ $1 == "--handles" ]]; then
   echo -n "azure-image"

--- a/golangci.yml
+++ b/golangci.yml
@@ -16,4 +16,4 @@ linters:
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/deislabs/duffle
+    local-prefixes: github.com/cnabio/duffle

--- a/governance.md
+++ b/governance.md
@@ -7,7 +7,7 @@ Maintainers MUST remain active. If they are unresponsive for >3 months, they wil
 
 New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers.
 
-A maintainer may step down by submitting an [issue](https://github.com/deislabs/duffle/issues/new) stating their intent.
+A maintainer may step down by submitting an [issue](https://github.com/cnabio/duffle/issues/new) stating their intent.
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -14,8 +14,8 @@ import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/pkg/errors"
 
-	"github.com/deislabs/duffle/pkg/duffle/manifest"
-	"github.com/deislabs/duffle/pkg/imagebuilder"
+	"github.com/cnabio/duffle/pkg/duffle/manifest"
+	"github.com/cnabio/duffle/pkg/imagebuilder"
 )
 
 // Builder defines how to interact with a bundle builder

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/bundle/definition"
 
-	"github.com/deislabs/duffle/pkg/duffle/manifest"
-	"github.com/deislabs/duffle/pkg/imagebuilder"
+	"github.com/cnabio/duffle/pkg/duffle/manifest"
+	"github.com/cnabio/duffle/pkg/imagebuilder"
 )
 
 // testImage represents a mock invocation image

--- a/pkg/duffle/manifest/load.go
+++ b/pkg/duffle/manifest/load.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/deislabs/duffle/pkg/duffle"
+	"github.com/cnabio/duffle/pkg/duffle"
 )
 
 // Load parses the named file into a manifest.

--- a/pkg/imagebuilder/docker/builder.go
+++ b/pkg/imagebuilder/docker/builder.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/deislabs/duffle/pkg/duffle/manifest"
+	"github.com/cnabio/duffle/pkg/duffle/manifest"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image/build"

--- a/pkg/imagebuilder/docker/builder_test.go
+++ b/pkg/imagebuilder/docker/builder_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/imagebuilder"
+	"github.com/cnabio/duffle/pkg/imagebuilder"
 )
 
 func TestArchiveSrc(t *testing.T) {

--- a/pkg/imagebuilder/mock/builder.go
+++ b/pkg/imagebuilder/mock/builder.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/deislabs/duffle/pkg/duffle/manifest"
+	"github.com/cnabio/duffle/pkg/duffle/manifest"
 )
 
 // Builder represents a mock builder

--- a/pkg/imagebuilder/mock/builder_test.go
+++ b/pkg/imagebuilder/mock/builder_test.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"testing"
 
-	"github.com/deislabs/duffle/pkg/imagebuilder"
+	"github.com/cnabio/duffle/pkg/imagebuilder"
 )
 
 // test mock Builder is assignable to the imagebuilder.ImageBuilder interface

--- a/pkg/imagestore/construction/construction.go
+++ b/pkg/imagestore/construction/construction.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/deislabs/duffle/pkg/imagestore"
-	"github.com/deislabs/duffle/pkg/imagestore/ocilayout"
-	"github.com/deislabs/duffle/pkg/imagestore/remote"
+	"github.com/cnabio/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore/ocilayout"
+	"github.com/cnabio/duffle/pkg/imagestore/remote"
 )
 
 var (

--- a/pkg/imagestore/construction/construction_test.go
+++ b/pkg/imagestore/construction/construction_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/deislabs/duffle/pkg/imagestore"
-	"github.com/deislabs/duffle/pkg/imagestore/imagestoremocks"
+	"github.com/cnabio/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore/imagestoremocks"
 )
 
 func TestNewLocatingConstructor(t *testing.T) {

--- a/pkg/imagestore/ocilayout/ocilayout.go
+++ b/pkg/imagestore/ocilayout/ocilayout.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/registry"
 
-	"github.com/deislabs/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore"
 )
 
 // ociLayout is an image store which stores images as an OCI image layout.

--- a/pkg/imagestore/remote/remote.go
+++ b/pkg/imagestore/remote/remote.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/registry"
 
-	"github.com/deislabs/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore"
 )
 
 // remote is an image store which does not actually store images. It is used to represent thin bundles.

--- a/pkg/imagestore/store_test.go
+++ b/pkg/imagestore/store_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/deislabs/duffle/pkg/imagestore/imagestoremocks"
+	"github.com/cnabio/duffle/pkg/imagestore/imagestoremocks"
 )
 
 func TestCreateParams(t *testing.T) {

--- a/pkg/packager/export.go
+++ b/pkg/packager/export.go
@@ -12,7 +12,7 @@ import (
 	"github.com/deislabs/cnab-go/bundle/loader"
 	"github.com/docker/docker/pkg/archive"
 
-	"github.com/deislabs/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore"
 )
 
 type Exporter struct {

--- a/pkg/packager/export_test.go
+++ b/pkg/packager/export_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/deislabs/cnab-go/bundle/loader"
 
-	"github.com/deislabs/duffle/pkg/imagestore"
-	"github.com/deislabs/duffle/pkg/imagestore/imagestoremocks"
+	"github.com/cnabio/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore/imagestoremocks"
 )
 
 func TestExport(t *testing.T) {

--- a/pkg/packager/import.go
+++ b/pkg/packager/import.go
@@ -43,7 +43,7 @@ func NewImporter(source, destination string, load loader.BundleLoader, verbose b
 func (im *Importer) Import() error {
 	_, _, err := im.Unzip()
 
-	// TODO: https://github.com/deislabs/duffle/issues/758
+	// TODO: https://github.com/cnabio/duffle/issues/758
 
 	return err
 }

--- a/pkg/relocator/relocator.go
+++ b/pkg/relocator/relocator.go
@@ -8,7 +8,7 @@ import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/pivotal/image-relocation/pkg/image"
 
-	"github.com/deislabs/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore"
 )
 
 type Relocator struct {

--- a/pkg/relocator/relocator_test.go
+++ b/pkg/relocator/relocator_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/pivotal/image-relocation/pkg/image"
 
-	"github.com/deislabs/duffle/pkg/imagestore/imagestoremocks"
-	"github.com/deislabs/duffle/pkg/relocator"
+	"github.com/cnabio/duffle/pkg/imagestore/imagestoremocks"
+	"github.com/cnabio/duffle/pkg/relocator"
 
 	"github.com/deislabs/cnab-go/bundle"
 
-	"github.com/deislabs/duffle/pkg/imagestore"
+	"github.com/cnabio/duffle/pkg/imagestore"
 )
 
 func TestRelocator_Relocate(t *testing.T) {


### PR DESCRIPTION
This PR updates the import paths for Duffle to `github.com/cnabio/duffle`.
This does *not* update the import paths for `cnab-go` because it would be state where the requested package for `cnab-go` would be `github.com/cnabio/cnab-go`, but the actual source code would contain `github.com/deislabs/cnab-go`, which results in inconsistencies.


Once we update the version of `cnab-go` used in Duffle to at least [v0.8.0-beta1](https://github.com/cnabio/cnab-go/releases/tag/v0.8.0-beta1) (which is the first version with the new import path), we can update the imported path, and we should also move to Go modules, like most other Go project in `cnabio`.
But I would very much prefer to make the changes incrementally.