### PR TITLE
chore(examples): update py/pip to v3 to appease azure-cli build

### DIFF
--- a/examples/aks-terraform/cnab/Dockerfile
+++ b/examples/aks-terraform/cnab/Dockerfile
@@ -8,10 +8,10 @@ RUN apk add --update git curl openssh bash-completion && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
     rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     apk update && \
-    apk add bash py-pip && \
-    apk add --virtual=build gcc libffi-dev musl-dev openssl-dev python-dev make && \
-    pip install --upgrade pip && \
-    pip install azure-cli
+    apk add bash py3-pip && \
+    apk add --virtual=build gcc libffi-dev musl-dev openssl-dev python3-dev make && \
+    pip3 install --upgrade pip && \
+    pip3 install azure-cli
 
 COPY Dockerfile /cnab/Dockerfile
 COPY app /cnab/app

--- a/examples/wordpress-mysql/cnab/Dockerfile
+++ b/examples/wordpress-mysql/cnab/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --update ca-certificates \
  && tar -xvf helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz \
  && mv linux-amd64/helm /usr/local/bin \
  && rm -f /helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz \
- && apk add bash py-pip \
- && apk add --virtual=build gcc libffi-dev musl-dev openssl-dev python-dev make \
- && pip install --upgrade pip \
- && pip install azure-cli \
+ && apk add bash py3-pip \
+ && apk add --virtual=build gcc libffi-dev musl-dev openssl-dev python3-dev make \
+ && pip3 install --upgrade pip \
+ && pip3 install azure-cli \
  && apk del --purge deps \
  && rm /var/cache/apk/*
 


### PR DESCRIPTION
Updates the Dockerfile for the aks-terrraform and wordpress-mysql example bundles to use Python v3 utilities, as required by recent versions of azure-cli.

Fixes example build failure as seen in https://brigadecore.github.io/kashti/jobs/validate-examples-01e78qnvf6v093x69qmkw7h3sx