### PR TITLE
ci(Makefile): pin ajv to known working version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ endef
 .PHONY: get-ajv
 get-ajv:
 	@if ! $$(which ajv > /dev/null 2>&1); then \
-		npm install -g ajv-cli; \
+		npm install -g ajv-cli@3.3.0; \
 	fi
 
 .PHONY: get-schema


### PR DESCRIPTION
* Pins the ajv cli we use for schema validation to a known working version; fixes the validate-examples CI check